### PR TITLE
test: add idempotency test for follow()

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -47,6 +47,24 @@ fn test_follow() {
 }
 
 #[test]
+fn test_follow_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    client.follow(&alice, &bob);
+
+    let following = client.get_following(&alice);
+    assert_eq!(following.len(), 1);
+    assert_eq!(following.get(0).unwrap(), bob);
+}
+
+#[test]
 fn test_post_and_tip() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
Add `test_follow_is_idempotent` in `packages/contracts/contracts/linkora-contracts/src/test.rs` that calls `follow(alice, bob)` twice and asserts `get_following(alice)` still returns exactly one entry.

## Why this matters
Issue #1 calls out that `follow` already dedupes via `if !list.contains(&followee)` in `packages/contracts/contracts/linkora-contracts/src/lib.rs:89` but the invariant is only covered indirectly. A direct test locks in the behavior and protects future storage-path refactors from silently breaking duplicate-follow handling - which would bloat `get_following` results and throw off any follower-count UI on the frontend.

## Changes
- `packages/contracts/contracts/linkora-contracts/src/test.rs`: new `test_follow_is_idempotent` immediately after `test_follow`, matching that test's `Env::default() + mock_all_auths + register + Client + Address::generate` setup. Uses the `test_follow_is_idempotent` name suggested in the issue.

## Testing
```
$ cargo test test_follow_is_idempotent
...
running 1 test
test test::test_follow_is_idempotent ... ok

test result: ok. 1 passed; 0 failed
```

Fixes #1

This contribution was developed with AI assistance (Claude Code).


---

## 🚀 Join the Linkora Community

This project is built in the open and we'd love your help!

**👉 Join our Telegram group to discuss this issue, ask questions, and connect with other contributors:**
## [t.me/+13csp8G4ccRhY2Zk](https://t.me/+13csp8G4ccRhY2Zk)

Whether you're picking up this issue or just exploring — come say hi. All skill levels welcome.