### PR TITLE
fix(contracts): reject zero or negative tip amounts

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     Vec,
 };
 
-// ── Storage Keys ────────────────────────────────────────────────────────────
+// ── Storage Keys ─────────────────────────────────────────────────────────────────────
 
 const POSTS: Symbol = symbol_short!("POSTS");
 const POST_CT: Symbol = symbol_short!("POST_CT");
@@ -12,7 +12,7 @@ const PROFILES: Symbol = symbol_short!("PROFILES");
 const FOLLOWS: Symbol = symbol_short!("FOLLOWS");
 const POOLS: Symbol = symbol_short!("POOLS");
 
-// ── Data Types ───────────────────────────────────────────────────────────────
+// ── Data Types ───────────────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone)]
@@ -39,14 +39,14 @@ pub struct Pool {
     pub balance: i128,
 }
 
-// ── Contract ─────────────────────────────────────────────────────────────────
+// ── Contract ───────────────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct LinkoraContract;
 
 #[contractimpl]
 impl LinkoraContract {
-    // ── Profiles ─────────────────────────────────────────────────────────────
+    // ── Profiles ───────────────────────────────────────────────────────────────────────
 
     /// Register or update a profile. `creator_token` is the SEP-41 token the
     /// creator has already deployed; pass their own address if none yet.
@@ -77,7 +77,7 @@ impl LinkoraContract {
         profiles.get(user)
     }
 
-    // ── Social Graph ─────────────────────────────────────────────────────────
+    // ── Social Graph ───────────────────────────────────────────────────────────────────
 
     pub fn follow(env: Env, follower: Address, followee: Address) {
         follower.require_auth();
@@ -100,7 +100,7 @@ impl LinkoraContract {
             .unwrap_or(Vec::new(&env))
     }
 
-    // ── Posts ─────────────────────────────────────────────────────────────────
+    // ── Posts ─────────────────────────────────────────────────────────────────────────────
 
     pub fn create_post(env: Env, author: Address, content: String) -> u64 {
         author.require_auth();
@@ -137,11 +137,12 @@ impl LinkoraContract {
         posts.get(id)
     }
 
-    // ── Tipping ───────────────────────────────────────────────────────────────
+    // ── Tipping ─────────────────────────────────────────────────────────────────────────────
 
     /// Tip a post author. `token` is any SEP-41 token address.
     pub fn tip(env: Env, tipper: Address, post_id: u64, token: Address, amount: i128) {
         tipper.require_auth();
+        assert!(amount > 0, "tip amount must be positive");
         let mut posts: Map<u64, Post> = env
             .storage()
             .persistent()
@@ -160,7 +161,7 @@ impl LinkoraContract {
         env.storage().persistent().set(&POSTS, &posts);
     }
 
-    // ── Community Token Pool ──────────────────────────────────────────────────
+    // ── Community Token Pool ─────────────────────────────────────────────────────────────
 
     /// Deposit tokens into a named community pool.
     pub fn pool_deposit(

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -70,7 +70,7 @@ fn test_post_and_tip() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "tip amount must be positive")]
 fn test_tip_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -84,12 +84,11 @@ fn test_tip_zero_amount() {
     let token = setup_token(&env, &tipper);
 
     let post_id = client.create_post(&author, &String::from_str(&env, "Hello Linkora!"));
-    // must panic: zero is not a valid tip amount
     client.tip(&tipper, &post_id, &token, &0);
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "tip amount must be positive")]
 fn test_tip_negative_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -103,7 +102,6 @@ fn test_tip_negative_amount() {
     let token = setup_token(&env, &tipper);
 
     let post_id = client.create_post(&author, &String::from_str(&env, "Hello Linkora!"));
-    // must panic: negative amount would drain the author's balance
     client.tip(&tipper, &post_id, &token, &-100);
 }
 

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -70,6 +70,44 @@ fn test_post_and_tip() {
 }
 
 #[test]
+#[should_panic]
+fn test_tip_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+    let token = setup_token(&env, &tipper);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Hello Linkora!"));
+    // must panic: zero is not a valid tip amount
+    client.tip(&tipper, &post_id, &token, &0);
+}
+
+#[test]
+#[should_panic]
+fn test_tip_negative_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+    let token = setup_token(&env, &tipper);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Hello Linkora!"));
+    // must panic: negative amount would drain the author's balance
+    client.tip(&tipper, &post_id, &token, &-100);
+}
+
+#[test]
 fn test_pool_deposit_withdraw() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## 1. Problem

The `tip` function accepts an `amount: i128` but has no guard against zero or negative values. Two concrete exploits are possible:

- **Negative amount** — `token::Client::transfer(&tipper, &author, &-100)` reverses the transfer direction on Stellar, pulling tokens *from* the author *back to* the tipper. A malicious caller can drain an author's balance without spending anything.
- **Zero amount** — `tip(…, 0)` silently increments `tip_total` by zero, wastes gas, and produces misleading on-chain state.

## 2. Root Cause

`tip` calls `tipper.require_auth()` but never validates the sign of `amount` before forwarding it to the token transfer.

## 3. Solution

Add a single guard immediately after auth, consistent with the existing pattern in `pool_withdraw`:

```rust
pub fn tip(env: Env, tipper: Address, post_id: u64, token: Address, amount: i128) {
    tipper.require_auth();
    assert!(amount > 0, "tip amount must be positive");   // ← added
    …
}
```

This is a one-line change with zero impact on the existing ABI or storage schema.

## 4. Test Coverage

Two new tests document the expected failure behaviour:

| Test | Input | Expected |
|------|-------|----------|
| `test_tip_zero_amount` | `amount = 0` | panics with `"tip amount must be positive"` |
| `test_tip_negative_amount` | `amount = -100` | panics with `"tip amount must be positive"` |

`#[should_panic(expected = "…")]` is used (not bare `#[should_panic]`) so the test only passes for the specific assertion, preventing false positives from unrelated panics.

`test_post_and_tip` (amount = 500) is unchanged and continues to pass.

## 5. How to Verify

```bash
cd packages/contracts/contracts/linkora-contracts
cargo test
```

Expected: all 6 tests pass, including the 2 new ones.

## 6. Checklist

- [x] Guard added before any state read or token transfer
- [x] Zero amount rejected
- [x] Negative amount rejected
- [x] Existing `test_post_and_tip` unaffected
- [x] `#[should_panic(expected = "…")]` used for precise assertions
- [x] Style consistent with `pool_withdraw` assert pattern

## 7. References

Fixes #3