### PR TITLE
test: add test_follow_is_idempotent to cover duplicate follow dedupli…

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -90,3 +90,23 @@ fn test_pool_deposit_withdraw() {
     assert_eq!(pool.balance, 800);
     assert_eq!(TokenClient::new(&env, &token).balance(&user), 9_200);
 }
+
+#[test]
+fn test_follow_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // Follow bob twice from alice — should be deduplicated
+    client.follow(&alice, &bob);
+    client.follow(&alice, &bob);
+
+    let following = client.get_following(&alice);
+    // Bob must appear exactly once despite two follow calls
+    assert_eq!(following.len(), 1);
+    assert_eq!(following.get(0).unwrap(), bob);
+}


### PR DESCRIPTION
---

**Title:** `test: add test_follow_is_idempotent`

**Description:**

closes #1 

The `follow` function already deduplicates followees via the `contains` check, but this behavior had no focused test. This PR adds `test_follow_is_idempotent` which:

- Calls `follow(alice, bob)` twice from the same follower
- Asserts `get_following` returns exactly one address

This makes the deduplication contract explicit, helps contributors understand the social graph storage path, and will catch any regression if the guard is ever removed.

**Testing:** `cargo test` from `packages/contracts` — all existing tests continue to pass alongside the new one.

---
