### PR TITLE
fix: reject non-positive pool deposits

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -171,6 +171,7 @@ impl LinkoraContract {
         amount: i128,
     ) {
         depositor.require_auth();
+        assert!(amount > 0, "deposit amount must be positive");
         let contract = env.current_contract_address();
         token::Client::new(&env, &token).transfer(&depositor, &contract, &amount);
 

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -90,3 +90,35 @@ fn test_pool_deposit_withdraw() {
     assert_eq!(pool.balance, 800);
     assert_eq!(TokenClient::new(&env, &token).balance(&user), 9_200);
 }
+
+#[test]
+#[should_panic(expected = "deposit amount must be positive")]
+fn test_pool_deposit_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let token = setup_token(&env, &user);
+    let pool_id = symbol_short!("community");
+
+    client.pool_deposit(&user, &pool_id, &token, &0);
+}
+
+#[test]
+#[should_panic(expected = "deposit amount must be positive")]
+fn test_pool_deposit_rejects_negative_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let token = setup_token(&env, &user);
+    let pool_id = symbol_short!("community");
+
+    client.pool_deposit(&user, &pool_id, &token, &-1);
+}


### PR DESCRIPTION
## Summary
- reject zero and negative amounts in `pool_deposit` before any transfer or state mutation
- add contract tests covering zero and negative deposit attempts

## Verification
- `cargo test` from `packages/contracts` (not runnable in my local environment because `cargo` is unavailable)

Closes #4