### PR TITLE
docs: add minimal pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Checklist
+
+- [ ] I have run the existing tests and they pass (`cargo test`).
+- [ ] I have added or updated documentation for any public-facing changes (README, inline comments, or contract docs).
+- [ ] The scope of this PR is focused (one concern per PR).
+- [ ] If this changes a contract API (storage keys, exported functions, or event shapes), I have noted the breaking or additive nature below.
+
+## Contract API Changes (if any)
+
+<!-- List any changes to contract interfaces, storage keys, or events. -->


### PR DESCRIPTION
Closes #10\n\nThis PR adds a lightweight PR template under `.github/pull_request_template.md` to help keep contributions consistent.\n\nThe checklist covers:\n- Running tests (`cargo test`)\n- Updating docs for public-facing changes\n- Keeping PR scope focused\n- Noting any contract API changes\n\nThe template is minimal so first-time contributors are not overwhelmed.

---

## 🚀 Join the Linkora Community

This project is built in the open and we'd love your help!

**👉 Join our Telegram group to discuss this issue, ask questions, and connect with other contributors:**
## [t.me/+13csp8G4ccRhY2Zk](https://t.me/+13csp8G4ccRhY2Zk)

Whether you're picking up this issue or just exploring — come say hi. All skill levels welcome.