### PR TITLE
feat/add-like-post-reaction-system-with-on-chain-counts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The primary contract is `LinkoraContract`.
 ### Data Models
 
 - `Profile`: stores a user address, username, and creator token address
-- `Post`: stores post id, author, content, total tips, and timestamp
+- `Post`: stores post id, author, content, total tips, timestamp, and like count
 - `Pool`: stores a pool token address and tracked balance
 
 ### Public Functions
@@ -81,6 +81,12 @@ The primary contract is `LinkoraContract`.
   Returns a post by id if it exists.
 - `tip(tipper, post_id, token, amount)`
   Transfers SEP-41 tokens to the post author and updates the post tip total.
+- `like_post(user, post_id)`
+  Records a like reaction from a user for a post. Idempotent.
+- `get_like_count(post_id)`
+  Returns the total number of likes for a post.
+- `has_liked(user, post_id)`
+  Returns whether a user has liked a specific post.
 - `pool_deposit(depositor, pool_id, token, amount)`
   Deposits tokens into a community pool tracked by `pool_id`.
 - `pool_withdraw(recipient, pool_id, amount)`

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -12,6 +12,7 @@ const PROFILES: Symbol = symbol_short!("PROFILES");
 const FOLLOWS: Symbol = symbol_short!("FOLLOWS");
 const POOLS: Symbol = symbol_short!("POOLS");
 const ADMIN: Symbol = symbol_short!("ADMIN");
+const LIKES: Symbol = symbol_short!("LIKES");
 
 // ── Data Types ───────────────────────────────────────────────────────────────
 
@@ -23,6 +24,7 @@ pub struct Post {
     pub content: String,
     pub tip_total: i128,
     pub timestamp: u64,
+    pub like_count: u64,
 }
 
 #[contracttype]
@@ -125,6 +127,7 @@ impl LinkoraContract {
             content,
             tip_total: 0,
             timestamp: env.ledger().timestamp(),
+            like_count: 0,
         };
         let mut posts: Map<u64, Post> = env
             .storage()
@@ -144,6 +147,47 @@ impl LinkoraContract {
             .get(&POSTS)
             .unwrap_or(Map::new(&env));
         posts.get(id)
+    }
+
+    // ── Reactions ────────────────────────────────────────────────────────────
+
+    pub fn like_post(env: Env, user: Address, post_id: u64) {
+        user.require_auth();
+
+        let key = (LIKES, post_id, user.clone());
+        if env.storage().persistent().has(&key) {
+            return;
+        }
+
+        let mut posts: Map<u64, Post> = env
+            .storage()
+            .persistent()
+            .get(&POSTS)
+            .unwrap_or(Map::new(&env));
+
+        if let Some(mut post) = posts.get(post_id) {
+            post.like_count += 1;
+            posts.set(post_id, post);
+            env.storage().persistent().set(&POSTS, &posts);
+            env.storage().persistent().set(&key, &true);
+        } else {
+            panic!("post not found");
+        }
+    }
+
+    pub fn get_like_count(env: Env, post_id: u64) -> u64 {
+        let posts: Map<u64, Post> = env
+            .storage()
+            .persistent()
+            .get(&POSTS)
+            .unwrap_or(Map::new(&env));
+
+        posts.get(post_id).map(|p| p.like_count).unwrap_or(0)
+    }
+
+    pub fn has_liked(env: Env, user: Address, post_id: u64) -> bool {
+        let key = (LIKES, post_id, user);
+        env.storage().persistent().has(&key)
     }
 
     // ── Tipping ───────────────────────────────────────────────────────────────

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -128,3 +128,32 @@ fn test_sequential_posts() {
     // Verify both exist and are distinct
     assert!(post_id1 != post_id2);
 }
+
+#[test]
+fn test_like_post() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let author = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Test post"));
+
+    // First like
+    client.like_post(&user1, &post_id);
+    assert_eq!(client.get_like_count(&post_id), 1);
+    assert!(client.has_liked(&user1, &post_id));
+
+    // Duplicate like (should be idempotent)
+    client.like_post(&user1, &post_id);
+    assert_eq!(client.get_like_count(&post_id), 1);
+
+    // Another user likes
+    client.like_post(&user2, &post_id);
+    assert_eq!(client.get_like_count(&post_id), 2);
+    assert!(client.has_liked(&user2, &post_id));
+}


### PR DESCRIPTION
Closes #26 

Changes Made:
Contract Data Model:
Extended the Post struct in src/lib.rs with a like_count: u64 field.
Added a new storage key constant LIKES for tracking individual user likes to ensure idempotency.
Contract Logic:
Updated create_post to initialize like_count to 0.
Implemented like_post(env, user, post_id):
Requires user authentication.
Checks for existing likes to ensure a user can only like a post once (idempotent).
Increments the like_count within the Post object and records the user's like reaction in persistent storage.
Implemented get_like_count(env, post_id) to return the total likes for a given post.
Implemented has_liked(env, user, post_id) to check if a specific user has liked a post.
Testing:
Added a comprehensive test case test_like_post in src/test.rs.
Verified the following scenarios:
First-time like incrementing the count correctly.
Duplicate likes from the same user being ignored (idempotency).
Likes from multiple users aggregating correctly.
Documentation:
Updated README.md to include the new like_count field in the Post model description.
Added the new public functions (like_post, get_like_count, has_liked) to the documentation.