### PR TITLE
feat: expose post counter via `get_post_count()` read function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The primary contract is `LinkoraContract`.
 | `follow(follower, followee)` | Record a follow relationship. Duplicate follows are ignored. | `follower` | `follower: Address` — account initiating the follow<br>`followee: Address` — account being followed | `()` |
 | `get_following(user)` | Return all accounts followed by a user. | None | `user: Address` | `Vec<Address>` |
 | `create_post(author, content)` | Publish a new on-chain post. Post IDs are assigned sequentially starting at 1. | `author` | `author: Address` — post creator<br>`content: String` — post body | `u64` — new post ID |
+| `get_post_count()` | Return the total number of posts created so far. Returns `0` when no posts exist. | None | None | `u64` |
 | `get_post(id)` | Fetch a post by ID. | None | `id: u64` | `Option<Post>` |
 | `tip(tipper, post_id, token, amount)` | Transfer SEP-41 tokens directly to a post's author and increment the post's `tip_total`. | `tipper` | `tipper: Address` — sender<br>`post_id: u64` — target post<br>`token: Address` — SEP-41 token contract<br>`amount: i128` — token units to transfer | `()` |
 | `pool_deposit(depositor, pool_id, token, amount)` | Deposit tokens into a named community pool. `amount` must be greater than zero. | `depositor` | `depositor: Address` — token sender<br>`pool_id: Symbol` — pool identifier<br>`token: Address` — SEP-41 token contract<br>`amount: i128` — token units to deposit (must be > 0) | `()` |

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -278,6 +278,10 @@ impl LinkoraContract {
         id
     }
 
+    pub fn get_post_count(env: Env) -> u64 {
+        env.storage().instance().get(&POST_CT).unwrap_or(0u64)
+    }
+
     pub fn get_post(env: Env, id: u64) -> Option<Post> {
         let key = (POSTS, id);
         let result: Option<Post> = env.storage().persistent().get(&key);

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -81,7 +81,25 @@ fn test_sequential_posts() {
     assert_eq!(id2, 2);
     assert_eq!(client.get_post(&id2).unwrap().timestamp, 2000);
 }
+#[test]
+fn test_get_post_count_after_create_and_delete() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+    let author = Address::generate(&env);
 
+    assert_eq!(client.get_post_count(), 0);
+
+    let id1 = client.create_post(&author, &String::from_str(&env, "First post"));
+    assert_eq!(client.get_post_count(), 1);
+
+    let _id2 = client.create_post(&author, &String::from_str(&env, "Second post"));
+    assert_eq!(client.get_post_count(), 2);
+
+    client.delete_post(&author, &id1);
+    assert_eq!(client.get_post_count(), 2);
+}
 // ── Pool tests ────────────────────────────────────────────────────────────────
 
 #[test]

--- a/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_get_post_count_after_create_and_delete.1.json
+++ b/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_get_post_count_after_create_and_delete.1.json
@@ -1,0 +1,275 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_post",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "First post"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_post",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "Second post"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "delete_post",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "POSTS"
+                  },
+                  {
+                    "u64": "2"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "author"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "content"
+                    },
+                    "val": {
+                      "string": "Second post"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "2"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "like_count"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "tip_total"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 535000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "POST_CT"
+                      },
+                      "val": {
+                        "u64": "2"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
closes #80 

## **Title**

**feat: expose post counter via `get_post_count()` read function**

---

## **Description**

This PR exposes the `POST_CT` counter through a public read function, `get_post_count()`, allowing clients and indexers to retrieve the total number of posts **without scanning all possible post IDs**.

This improves efficiency for consumers that need total-post metadata while preserving existing behavior.

---

## **📌 Summary of Changes**

### **Implementation**

**Function Added**

```rust
get_post_count(env: Env) -> u64
```

**Location:** `lib.rs` (lines 283–285)

**Behavior**

* Returns total number of posts created
* Returns `0` if no posts exist
* Reads directly from instance storage key:

```rust
POST_CT
```

---

## **🧪 Testing**

### **New Test Added**

**Test:** `test_get_post_count_after_create_and_delete`

**Location:** `test.rs` (lines 90–105)

### Verifies:

* Count starts at **0**
* Count increments correctly after `create_post`
* Count persists after `delete_post`
  *(counter does not decrement by design)*

**Result:** ✅ Passed

---

## **📋 Test Results**

Running **16 tests**

```text
test test::test_get_post_count_after_create_and_delete ... ok
test test::test_follow_is_idempotent ... ok
test test::test_like_post ... ok
test test::test_pool_deposit_negative_amount - should panic ... ok
test test::test_pool_withdraw_negative_amount - should panic ... ok
test test::test_sequential_posts ... ok
test test::test_set_and_get_profile ... ok
test test::test_pool_withdraw_zero_amount - should panic ... ok
test test::test_ttl_extended_after_create_post ... ok
test test::test_ttl_extended_after_follow ... ok
test test::test_ttl_extended_after_pool_deposit ... ok
test test::test_ttl_extended_after_set_profile ... ok
test test::test_ttl_extended_on_get_post ... ok
test test::test_ttl_extended_on_get_pool ... ok
test test::test_ttl_extended_on_get_profile ... ok

test result: ok. 16 passed; 0 failed; 0 ignored
```

---

## **📚 Documentation**

### Updated `README.md`

Updated API table (line 77) to include:

* New function signature
* Function description
* Usage reference

---

## **✅ Acceptance Criteria Met**

* ✅ Added `get_post_count(env: Env) -> u64`
* ✅ Returns `0` when no posts exist
* ✅ Returns correct count after create + delete operations
* ✅ Documented in README API table
* ✅ Added unit test validating behavior across multiple posts

---

## **📁 Files Changed**

### `lib.rs`

* Added public read function

### `test.rs`

* Added regression test

### `README.md`

* Updated API documentation

### Test Snapshots

* Updated auto-generated snapshots for new test

---

## **📈 Impact**

* **Efficiency:** Indexers can fetch total post count without scanning IDs
* **Usability:** Improves client-side pagination and metadata access
* **Compatibility:** Non-breaking addition to existing API surface

---

## **⚠️ Breaking Changes**

None — this is a backward-compatible feature addition.

---

## **🧾 Type of Change**

* ✅ New feature (non-breaking functionality)

---

## **✅ Checklist**

* ✅ Code compiles without errors
* ✅ All tests pass locally
* ✅ New test added for feature
* ✅ Documentation updated
* ✅ Commit message follows conventional commits

---

## **📌 Next Steps**

* Consider exposing additional aggregate counters (likes, follows, pools)
* Evaluate event emission for post count changes
* Add indexer examples showing usage of `get_post_count()`
