### PR TITLE
feat: add unfollow with reverse index + test coverage (closes #67)

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -10,6 +10,7 @@ const POSTS: Symbol = symbol_short!("POSTS");
 const POST_CT: Symbol = symbol_short!("POST_CT");
 const PROFILES: Symbol = symbol_short!("PROFILES");
 const FOLLOWS: Symbol = symbol_short!("FOLLOWS");
+const FOLLOWERS: Symbol = symbol_short!("FOLLOWERS");
 const POOLS: Symbol = symbol_short!("POOLS");
 const ADMIN: Symbol = symbol_short!("ADMIN");
 
@@ -90,22 +91,83 @@ impl LinkoraContract {
 
     pub fn follow(env: Env, follower: Address, followee: Address) {
         follower.require_auth();
-        let key = (FOLLOWS, follower.clone());
-        let mut list: Vec<Address> = env
+
+        // Forward index: follower -> [followees]
+        let fwd_key = (FOLLOWS, follower.clone());
+        let mut fwd: Vec<Address> = env
             .storage()
             .persistent()
-            .get(&key)
+            .get(&fwd_key)
             .unwrap_or(Vec::new(&env));
-        if !list.contains(&followee) {
-            list.push_back(followee);
+        if !fwd.contains(&followee) {
+            fwd.push_back(followee.clone());
+            env.storage().persistent().set(&fwd_key, &fwd);
+
+            // Reverse index: followee -> [followers]
+            let rev_key = (FOLLOWERS, followee.clone());
+            let mut rev: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&rev_key)
+                .unwrap_or(Vec::new(&env));
+            rev.push_back(follower);
+            env.storage().persistent().set(&rev_key, &rev);
         }
-        env.storage().persistent().set(&key, &list);
+    }
+
+    pub fn unfollow(env: Env, follower: Address, followee: Address) {
+        follower.require_auth();
+
+        // Forward index: remove followee from follower's list
+        let fwd_key = (FOLLOWS, follower.clone());
+        let fwd: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&fwd_key)
+            .unwrap_or(Vec::new(&env));
+
+        // Find position; if not present, no-op
+        let pos = fwd.iter().position(|a| a == followee);
+        if let Some(idx) = pos {
+            let mut new_fwd: Vec<Address> = Vec::new(&env);
+            for (i, a) in fwd.iter().enumerate() {
+                if i != idx {
+                    new_fwd.push_back(a);
+                }
+            }
+            env.storage().persistent().set(&fwd_key, &new_fwd);
+
+            // Reverse index: remove follower from followee's list
+            let rev_key = (FOLLOWERS, followee.clone());
+            let rev: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&rev_key)
+                .unwrap_or(Vec::new(&env));
+            let rev_pos = rev.iter().position(|a| a == follower);
+            if let Some(ridx) = rev_pos {
+                let mut new_rev: Vec<Address> = Vec::new(&env);
+                for (i, a) in rev.iter().enumerate() {
+                    if i != ridx {
+                        new_rev.push_back(a);
+                    }
+                }
+                env.storage().persistent().set(&rev_key, &new_rev);
+            }
+        }
     }
 
     pub fn get_following(env: Env, user: Address) -> Vec<Address> {
         env.storage()
             .persistent()
             .get(&(FOLLOWS, user))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_followers(env: Env, user: Address) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&(FOLLOWERS, user))
             .unwrap_or(Vec::new(&env))
     }
 

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -91,6 +91,78 @@ fn test_pool_deposit_withdraw() {
     assert_eq!(TokenClient::new(&env, &token).balance(&user), 9_200);
 }
 
+// ── Unfollow tests ────────────────────────────────────────────────────────────
+
+/// follow then unfollow: get_following returns empty list.
+#[test]
+fn test_unfollow_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    assert_eq!(client.get_following(&alice).len(), 1);
+
+    client.unfollow(&alice, &bob);
+    assert_eq!(client.get_following(&alice).len(), 0);
+}
+
+/// unfollow on a relationship that does not exist must not panic.
+#[test]
+fn test_unfollow_noop_on_missing_relationship() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // Never followed — should be a silent no-op
+    client.unfollow(&alice, &bob);
+    assert_eq!(client.get_following(&alice).len(), 0);
+}
+
+/// after unfollow, get_followers no longer includes the unfollowed address.
+#[test]
+fn test_unfollow_removes_from_reverse_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    assert_eq!(client.get_followers(&bob).len(), 1);
+
+    client.unfollow(&alice, &bob);
+    assert_eq!(client.get_followers(&bob).len(), 0);
+}
+
+/// double unfollow must not panic.
+#[test]
+fn test_double_unfollow_does_not_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    client.unfollow(&alice, &bob);
+    // second unfollow on an already-removed relationship — must not panic
+    client.unfollow(&alice, &bob);
+    assert_eq!(client.get_following(&alice).len(), 0);
+}
+
 #[test]
 fn test_sequential_posts() {
     let env = Env::default();


### PR DESCRIPTION
---

**Title:** `feat: unfollow implementation + test coverage (closes #67)`

**Description:**

`unfollow` was implemented but had no test coverage, and the reverse index (`get_followers`) was missing entirely, making the index symmetry tests impossible.

**Changes:**

- Added `FOLLOWERS` storage key for the reverse index
- Updated `follow()` to maintain both forward (`FOLLOWS`) and reverse (`FOLLOWERS`) indexes atomically
- Added `unfollow()` — removes from both indexes; silent no-op when the relationship doesn't exist
- Added `get_followers()` to expose the reverse index

**Tests added (`test.rs`):**

- `test_unfollow_success` — follow then unfollow; `get_following` returns empty
- `test_unfollow_noop_on_missing_relationship` — unfollow with no prior follow doesn't panic
- `test_unfollow_removes_from_reverse_index` — `get_followers` is empty after unfollow (fixes the reverse index bug)
- `test_double_unfollow_does_not_panic` — calling unfollow twice is safe