### PR TITLE
test: add test suite and corresponding snapshots for contract functions

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -100,6 +100,61 @@ fn test_get_post_count_after_create_and_delete() {
     client.delete_post(&author, &id1);
     assert_eq!(client.get_post_count(), 2);
 }
+
+#[test]
+fn test_delete_post_success() {
+    use soroban_sdk::{testutils::Events, IntoVal};
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+    let author = Address::generate(&env);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "To be deleted"));
+    assert!(client.get_post(&post_id).is_some());
+
+    client.delete_post(&author, &post_id);
+    let events = env.events().all();
+    assert!(client.get_post(&post_id).is_none());
+    assert_eq!(
+        events,
+        soroban_sdk::vec![
+            &env,
+            (
+                contract_id.clone(),
+                (symbol_short!("Linkora"), symbol_short!("post_del"), symbol_short!("v1")).into_val(&env),
+                PostDeleted { post_id, author: author.clone() }.into_val(&env)
+            )
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "only author can delete post")]
+fn test_delete_post_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+    let author = Address::generate(&env);
+    let other_user = Address::generate(&env);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Cannot delete this"));
+    
+    client.delete_post(&other_user, &post_id);
+}
+
+#[test]
+#[should_panic(expected = "post does not exist")]
+fn test_delete_post_non_existent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+    let author = Address::generate(&env);
+
+    client.delete_post(&author, &999);
+}
 // ── Pool tests ────────────────────────────────────────────────────────────────
 
 #[test]

--- a/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_delete_post_non_existent.1.json
+++ b/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_delete_post_non_existent.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_delete_post_unauthorized_caller.1.json
+++ b/packages/contracts/contracts/linkora-contracts/test_snapshots/test/test_delete_post_unauthorized_caller.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -19,30 +19,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "To be deleted"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "delete_post",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "u64": "1"
+                  "string": "Cannot delete this"
                 }
               ]
             }
@@ -63,6 +40,82 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "POSTS"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "author"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "content"
+                    },
+                    "val": {
+                      "string": "Cannot delete this"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "like_count"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "tip_total"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 535000
+      },
       {
         "entry": {
           "last_modified_ledger_seq": 0,
@@ -105,26 +158,6 @@
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",


### PR DESCRIPTION
#closes #65 

Pull Request: Add test coverage for delete_post
Description
Fixes #65

This PR introduces comprehensive unit test coverage for the delete_post functionality within the linkora-contracts module. While the delete_post function was already implemented in the core contract, it lacked critical test paths, making it susceptible to regressions or unauthorized access if the logic were later modified.

The added tests verify the contract's expected behavior across successful deletion, permission checks, and edge cases.

Changes Made
Added test_delete_post_success:
Verifies that an author can successfully delete their own post.
Confirms that a subsequent call to get_post returns None for the deleted post.
Asserts that the PostDeleted event is correctly formatted, published, and recorded in the environment's event list immediately following the deletion.
Added test_delete_post_unauthorized_caller:
Evaluates the access control mechanisms by attempting to delete a post using an account that is not the post's author.
Ensures the operation is rejected and panics with the exact expected error message: "only author can delete post".
Added test_delete_post_non_existent:
Verifies robustness when interacting with invalid states by attempting to delete a post ID that has not been created (e.g., ID 999).
Ensures the transaction is aborted and panics with the expected error message: "post does not exist".
Acceptance Criteria Met
 Test: author deletes their own post; get_post returns None afterwards.
 Test: non-author calling delete_post panics with "only author can delete post".
 Test: deleting a non-existent post ID panics with "post does not exist".
 Test: PostDeleted event is present in env.events().all() after successful deletion.
Testing Instructions
To verify these changes locally:

Clone this branch and navigate to the contracts package:
bash
cd packages/contracts
Run the test suite using Cargo:
bash
cargo test
Ensure that 19 tests run and pass successfully (test result: ok. 19 passed).

#closes 