### PR TITLE
feat: pin and verify stellar-cli version in e2e script and CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
           workspaces: packages/contracts
 
       - name: Install stellar-cli
-        run: cargo install --locked stellar-cli
+        run: cargo install --locked stellar-cli --version 22.8.1
 
       - name: Verify Docker is available
         run: docker info

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,12 +18,12 @@ The E2E script validates these flows on a running sandbox:
 
 - Docker
 - Rust toolchain
-- `stellar` CLI in `PATH`
+- `stellar` CLI **v22.8.1** in `PATH`
 
-Install CLI if needed:
+Install the required version:
 
 ```bash
-cargo install --locked stellar-cli
+cargo install --locked stellar-cli --version 22.8.1
 ```
 
 ## Run Locally

--- a/tests/integration/run_e2e.sh
+++ b/tests/integration/run_e2e.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REQUIRED_STELLAR_VERSION="22.8.1"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONTRACT_DIR="$ROOT_DIR/packages/contracts/contracts/linkora-contracts"
 CFG_DIR="$(mktemp -d)"
@@ -26,6 +28,13 @@ require_cmd() {
 require_cmd stellar
 require_cmd cargo
 require_cmd docker
+
+STELLAR_VERSION="$(stellar --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'| head -1)"
+if [[ "$STELLAR_VERSION" != "$REQUIRED_STELLAR_VERSION" ]]; then
+  echo "error: stellar-cli version mismatch (found $STELLAR_VERSION, required $REQUIRED_STELLAR_VERSION)" >&2
+  echo "  Install the correct version with: cargo install --locked stellar-cli --version $REQUIRED_STELLAR_VERSION" >&2
+  exit 1
+fi
 
 echo "[1/8] Starting local Stellar sandbox container..."
 stellar --config-dir "$CFG_DIR" container start local --name "$CONTAINER_NAME"


### PR DESCRIPTION
## Pin and verify `stellar-cli` version in e2e script and CI

### Problem

`run_e2e.sh` verified that `stellar`, `cargo`, and `docker` were installed but never checked the `stellar-cli` version. Breaking CLI changes between releases caused integration tests to fail with cryptic, hard-to-diagnose errors.

### Changes

**`tests/integration/run_e2e.sh`**
- Added `REQUIRED_STELLAR_VERSION="22.8.1"` variable at the top of the script.
- After the existing `require_cmd` checks, the script now reads `stellar --version`, extracts the semver, and exits with a clear error message if it doesn't match — including the exact `cargo install` command to fix it.

**`.github/workflows/integration.yml`**
- Pinned the `cargo install --locked stellar-cli` step to `--version 22.8.1` so CI always runs against the same version.

**`tests/README.md`**
- Updated prerequisites to document the required `stellar-cli` version.
- Replaced the generic install command with the pinned one.

### How to update the version in the future

1. Change `REQUIRED_STELLAR_VERSION` in `run_e2e.sh`.
2. Update `--version` in `.github/workflows/integration.yml`.
3. Update the version reference in `tests/README.md`.

close #78 