### PR TITLE
test/fix/docs: follow symmetry tests, pool event tests, e2e pool_withdraw fix, API table update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,34 @@ The primary contract is `LinkoraContract`.
 
 | Function | Purpose | Required signer | Inputs | Returns |
 |---|---|---|---|---|
-| `set_profile(user, username, creator_token)` | Register or update a creator profile. | `user` | `user: Address` — account being registered<br>`username: String` — display name<br>`creator_token: Address` — SEP-41 token the creator has deployed (pass own address if none) | `()` |
+| `initialize(admin, treasury, fee_bps)` | One-time contract setup. Panics if called more than once. | `admin` | `admin: Address` — contract administrator<br>`treasury: Address` — fee recipient<br>`fee_bps: u32` — protocol fee in basis points (0–10 000) | `()` |
+| `set_profile(user, username, creator_token)` | Register or update a creator profile. | `user` | `user: Address` — account being registered<br>`username: String` — display name (3–32 alphanumeric or `_` characters)<br>`creator_token: Address` — SEP-41 token the creator has deployed (pass own address if none) | `()` |
 | `get_profile(user)` | Fetch a profile by address. | None | `user: Address` | `Option<Profile>` |
-| `follow(follower, followee)` | Record a follow relationship. Duplicate follows are ignored. | `follower` | `follower: Address` — account initiating the follow<br>`followee: Address` — account being followed | `()` |
+| `get_profile_count()` | Return the total number of registered profiles. | None | None | `u64` |
+| `follow(follower, followee)` | Record a follow relationship. Duplicate follows are ignored. Panics if `followee` has blocked `follower`. | `follower` | `follower: Address` — account initiating the follow<br>`followee: Address` — account being followed | `()` |
+| `unfollow(follower, followee)` | Remove a follow relationship. No-op if the relationship does not exist. | `follower` | `follower: Address` — account removing the follow<br>`followee: Address` — account being unfollowed | `()` |
 | `get_following(user)` | Return all accounts followed by a user. | None | `user: Address` | `Vec<Address>` |
-| `create_post(author, content)` | Publish a new on-chain post. Post IDs are assigned sequentially starting at 1. | `author` | `author: Address` — post creator<br>`content: String` — post body | `u64` — new post ID |
+| `get_followers(user)` | Return all accounts that follow a user. | None | `user: Address` | `Vec<Address>` |
+| `block_user(blocker, blocked)` | Add an account to the caller's block list, preventing them from following. | `blocker` | `blocker: Address` — account initiating the block<br>`blocked: Address` — account being blocked | `()` |
+| `unblock_user(blocker, blocked)` | Remove an account from the caller's block list. | `blocker` | `blocker: Address` — account removing the block<br>`blocked: Address` — account being unblocked | `()` |
+| `is_blocked(blocker, blocked)` | Check whether `blocker` has blocked `blocked`. | None | `blocker: Address`<br>`blocked: Address` | `bool` |
+| `create_post(author, content)` | Publish a new on-chain post. Post IDs are assigned sequentially starting at 1. | `author` | `author: Address` — post creator<br>`content: String` — post body (1–280 characters) | `u64` — new post ID |
 | `get_post_count()` | Return the total number of posts created so far. Returns `0` when no posts exist. | None | None | `u64` |
 | `get_post(id)` | Fetch a post by ID. | None | `id: u64` | `Option<Post>` |
-| `tip(tipper, post_id, token, amount)` | Transfer SEP-41 tokens directly to a post's author and increment the post's `tip_total`. | `tipper` | `tipper: Address` — sender<br>`post_id: u64` — target post<br>`token: Address` — SEP-41 token contract<br>`amount: i128` — token units to transfer | `()` |
-| `pool_deposit(depositor, pool_id, token, amount)` | Deposit tokens into a named community pool. `amount` must be greater than zero. | `depositor` | `depositor: Address` — token sender<br>`pool_id: Symbol` — pool identifier<br>`token: Address` — SEP-41 token contract<br>`amount: i128` — token units to deposit (must be > 0) | `()` |
-| `pool_withdraw(recipient, pool_id, amount)` | Withdraw tokens from a community pool to the caller. `amount` must be greater than zero and must not exceed the pool balance. | `recipient` | `recipient: Address` — token receiver<br>`pool_id: Symbol` — pool identifier<br>`amount: i128` — token units to withdraw (must be > 0) | `()` |
+| `delete_post(author, post_id)` | Delete a post. Only the original author may delete their own post. | `author` | `author: Address` — post owner<br>`post_id: u64` — ID of the post to delete | `()` |
+| `like_post(user, post_id)` | Like a post. Duplicate likes from the same user are ignored. | `user` | `user: Address` — account liking the post<br>`post_id: u64` — target post | `()` |
+| `get_like_count(post_id)` | Return the number of likes on a post. | None | `post_id: u64` | `u64` |
+| `has_liked(user, post_id)` | Check whether a user has liked a specific post. | None | `user: Address`<br>`post_id: u64` | `bool` |
+| `tip(tipper, post_id, token, amount)` | Transfer SEP-41 tokens to a post's author, applying the protocol fee, and increment the post's `tip_total`. | `tipper` | `tipper: Address` — sender<br>`post_id: u64` — target post<br>`token: Address` — SEP-41 token contract<br>`amount: i128` — token units to transfer (must be > 0) | `()` |
+| `create_pool(admin, pool_id, token, initial_admins, threshold)` | Create a named community pool with an M-of-N admin set. Requires contract admin auth. | contract `admin` | `admin: Address` — caller (must be contract admin)<br>`pool_id: Symbol` — unique pool identifier<br>`token: Address` — SEP-41 token for the pool<br>`initial_admins: Vec<Address>` — admin set<br>`threshold: u32` — minimum signatures required to withdraw (must be > 0 and ≤ `initial_admins.len()`) | `()` |
+| `pool_deposit(depositor, pool_id, token, amount)` | Deposit tokens into a named community pool. `amount` must be greater than zero. | `depositor` | `depositor: Address` — token sender<br>`pool_id: Symbol` — pool identifier<br>`token: Address` — SEP-41 token contract (must match pool token)<br>`amount: i128` — token units to deposit (must be > 0) | `()` |
+| `pool_withdraw(signers, pool_id, amount, recipient)` | Withdraw tokens from a community pool. Requires at least `threshold` valid admin signatures from the pool's admin set. | each address in `signers` | `signers: Vec<Address>` — admin addresses authorising the withdrawal<br>`pool_id: Symbol` — pool identifier<br>`amount: i128` — token units to withdraw (must be > 0 and ≤ pool balance)<br>`recipient: Address` — token receiver | `()` |
 | `get_pool(pool_id)` | Fetch the current state of a pool. | None | `pool_id: Symbol` | `Option<Pool>` |
+| `set_fee(fee_bps)` | Update the protocol fee. Only callable by the contract admin. | contract `admin` | `fee_bps: u32` — new fee in basis points (0–10 000) | `()` |
+| `set_treasury(treasury)` | Update the treasury address that receives protocol fees. Only callable by the contract admin. | contract `admin` | `treasury: Address` — new fee recipient | `()` |
+| `get_fee_bps()` | Return the current protocol fee in basis points. | None | None | `u32` |
+| `get_treasury()` | Return the current treasury address. | None | None | `Option<Address>` |
+| `upgrade(new_wasm_hash)` | Upgrade the contract WASM. Only callable by the contract admin. | contract `admin` | `new_wasm_hash: BytesN<32>` — hash of the new WASM blob | `()` |
 
 ## Storage Layout
 
@@ -97,13 +114,17 @@ Linkora-socials uses Soroban's state storage to manage its data. Below is a summ
 | Key | Format | Namespace | Purpose |
 |---|---|---|---|
 | `PROFILES` | `(Symbol("PROFILES"), Address)` | Persistent | Stores user `Profile` data. |
+| `PROF_CT` | `Symbol("PROF_CT")` | Instance | Tracks the total number of registered profiles. |
 | `FOLLOWS` | `(Symbol("FOLLOWS"), Address)` | Persistent | Stores a `Vec<Address>` of accounts that the given address follows. |
 | `FOLLOWRS` | `(Symbol("FOLLOWRS"), Address)` | Persistent | Stores a `Vec<Address>` of accounts following the given address. |
+| `BLOCKS` | `(Symbol("BLOCKS"), Address)` | Persistent | Stores a `Map<Address, ()>` of accounts blocked by the given address. |
 | `POSTS` | `(Symbol("POSTS"), u64)` | Persistent | Stores individual `Post` objects by their incremental ID. |
 | `POST_CT` | `Symbol("POST_CT")` | Instance | Tracks the total number of posts created (used for ID generation). |
 | `POOLS` | `(Symbol("POOLS"), Symbol)` | Persistent | Stores `Pool` data for named community pools. |
 | `LIKES` | `(Symbol("LIKES"), u64, Address)` | Persistent | Records whether a specific user has liked a specific post. |
 | `ADMIN` | `Symbol("ADMIN")` | Instance | Stores the contract administrator's address. |
+| `TREASURY` | `Symbol("TREASURY")` | Instance | Stores the treasury address that receives protocol fees. |
+| `FEE_BPS` | `Symbol("FEE_BPS")` | Instance | Stores the protocol fee in basis points (0–10 000). |
 | `INIT` | `Symbol("INIT")` | Instance | Boolean flag indicating if the contract has been initialized. |
 
 > [!NOTE]
@@ -248,9 +269,8 @@ Please review `SECURITY.md` for vulnerability disclosure guidance and scope.
 
 This repository is a prototype and should not be treated as production-ready infrastructure yet.
 
-- Pool withdrawal authorization is minimal and should be replaced with stronger governance or role-based control.
+- Pool withdrawal uses M-of-N admin authorization; more advanced governance may be needed for production.
 - Contract storage layout has not been optimized for scale.
-- There are no emitted events yet for indexers or analytics pipelines.
 - No deployment scripts, frontend client, or backend service are included yet.
 - Security review and audit work remain outstanding.
 

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -274,3 +274,150 @@ fn test_delete_post_non_existent() {
     let author = Address::generate(&env);
     client.delete_post(&author, &999);
 }
+
+// ── Follow / unfollow reverse index symmetry (issue #138) ─────────────────────
+
+#[test]
+fn test_follow_populates_both_indexes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+
+    let following = client.get_following(&alice);
+    assert_eq!(following.len(), 1);
+    assert_eq!(following.get(0).unwrap(), bob);
+
+    let followers = client.get_followers(&bob);
+    assert_eq!(followers.len(), 1);
+    assert_eq!(followers.get(0).unwrap(), alice);
+}
+
+#[test]
+fn test_unfollow_clears_both_indexes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    client.unfollow(&alice, &bob);
+
+    assert_eq!(client.get_following(&alice).len(), 0);
+    assert_eq!(client.get_followers(&bob).len(), 0);
+}
+
+#[test]
+fn test_follow_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.follow(&alice, &bob);
+    client.follow(&alice, &bob);
+
+    assert_eq!(client.get_following(&alice).len(), 1);
+    assert_eq!(client.get_followers(&bob).len(), 1);
+}
+
+#[test]
+fn test_unfollow_noop_on_nonexistent_relationship() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // No prior follow — must not panic and both indexes must stay empty.
+    client.unfollow(&alice, &bob);
+
+    assert_eq!(client.get_following(&alice).len(), 0);
+    assert_eq!(client.get_followers(&bob).len(), 0);
+}
+
+// ── Pool deposit / withdraw event emission (issue #137) ───────────────────────
+
+#[test]
+fn test_pool_deposit_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let depositor = Address::generate(&env);
+    let token = setup_token(&env, &depositor);
+    let pool_id = symbol_short!("evt_dep");
+
+    client.create_pool(
+        &admin,
+        &pool_id,
+        &token,
+        &vec![&env, admin.clone()],
+        &1,
+    );
+
+    client.pool_deposit(&depositor, &pool_id, &token, &200);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, data)| {
+        // PoolDepositEvent topics: [depositor, pool_id]; data: amount
+        if topics.len() >= 2 {
+            let dep_match = topics.get(0).map(|t| t == depositor.clone().into_val(&env)).unwrap_or(false);
+            let pool_match = topics.get(1).map(|t| t == pool_id.clone().into_val(&env)).unwrap_or(false);
+            let amount_match = data == (200i128).into_val(&env);
+            dep_match && pool_match && amount_match
+        } else {
+            false
+        }
+    });
+    assert!(found, "PoolDepositEvent not found in emitted events");
+}
+
+#[test]
+fn test_pool_withdraw_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = setup_token(&env, &depositor);
+    let pool_id = symbol_short!("evt_wd");
+
+    client.create_pool(
+        &admin,
+        &pool_id,
+        &token,
+        &vec![&env, admin.clone()],
+        &1,
+    );
+
+    client.pool_deposit(&depositor, &pool_id, &token, &500);
+
+    // Consume deposit events before withdrawal so we can isolate the withdraw event.
+    let _ = env.events().all();
+
+    client.pool_withdraw(&vec![&env, admin.clone()], &pool_id, &150, &recipient);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, data)| {
+        if topics.len() >= 2 {
+            let rec_match = topics.get(0).map(|t| t == recipient.clone().into_val(&env)).unwrap_or(false);
+            let pool_match = topics.get(1).map(|t| t == pool_id.clone().into_val(&env)).unwrap_or(false);
+            let amount_match = data == (150i128).into_val(&env);
+            rec_match && pool_match && amount_match
+        } else {
+            false
+        }
+    });
+    assert!(found, "PoolWithdrawEvent not found in emitted events");
+}

--- a/tests/integration/run_e2e.sh
+++ b/tests/integration/run_e2e.sh
@@ -70,6 +70,12 @@ stellar --config-dir "$CFG_DIR" contract invoke \
   --network "$NETWORK" \
   --source-account linkora_alice \
   --id "$CONTRACT_ID" \
+  -- initialize --admin "$ALICE_ADDR" --treasury "$ALICE_ADDR" --fee-bps 0 >/dev/null
+
+stellar --config-dir "$CFG_DIR" contract invoke \
+  --network "$NETWORK" \
+  --source-account linkora_alice \
+  --id "$CONTRACT_ID" \
   -- set_profile --user "$ALICE_ADDR" --username alice --creator-token "$TOKEN_ID" >/dev/null
 
 stellar --config-dir "$CFG_DIR" contract invoke \
@@ -101,6 +107,12 @@ stellar --config-dir "$CFG_DIR" contract invoke \
 
 stellar --config-dir "$CFG_DIR" contract invoke \
   --network "$NETWORK" \
+  --source-account linkora_alice \
+  --id "$CONTRACT_ID" \
+  -- create_pool --admin "$ALICE_ADDR" --pool-id community --token "$TOKEN_ID" --admins "[\"$ALICE_ADDR\"]" --threshold 1 >/dev/null
+
+stellar --config-dir "$CFG_DIR" contract invoke \
+  --network "$NETWORK" \
   --source-account linkora_bob \
   --id "$CONTRACT_ID" \
   -- pool_deposit --depositor "$BOB_ADDR" --pool-id community --token "$TOKEN_ID" --amount 600 >/dev/null
@@ -109,7 +121,7 @@ stellar --config-dir "$CFG_DIR" contract invoke \
   --network "$NETWORK" \
   --source-account linkora_alice \
   --id "$CONTRACT_ID" \
-  -- pool_withdraw --recipient "$ALICE_ADDR" --pool-id community --amount 250 >/dev/null
+  -- pool_withdraw --signers "[\"$ALICE_ADDR\"]" --pool-id community --amount 250 --recipient "$ALICE_ADDR" >/dev/null
 
 echo "[7/8] Verifying end-to-end state..."
 FOLLOWING="$(stellar --config-dir "$CFG_DIR" contract invoke \


### PR DESCRIPTION
## Summary

- Add unit tests verifying follow/unfollow populates and clears both the following and followers indexes symmetrically, including idempotency and no-op unfollow cases
- Add unit tests verifying `pool_deposit` and `pool_withdraw` emit the expected `PoolDepositEvent` and `PoolWithdrawEvent` with correct topics and data
- Fix `tests/integration/run_e2e.sh`: add `initialize` call, add `create_pool` step before `pool_deposit`, and update `pool_withdraw` invocation to pass `--signers` and the correct parameter order matching the contract signature
- Expand the README API reference table with all 17 previously undocumented functions (`initialize`, `get_profile_count`, `unfollow`, `get_followers`, `block_user`, `unblock_user`, `is_blocked`, `delete_post`, `like_post`, `get_like_count`, `has_liked`, `create_pool`, `set_fee`, `set_treasury`, `get_fee_bps`, `get_treasury`, `upgrade`); update `pool_withdraw` entry for the `signers: Vec<Address>` parameter; add `PROF_CT`, `BLOCKS`, `TREASURY`, and `FEE_BPS` to the storage key table

## Test plan

- [ ] `cargo test` passes in `packages/contracts` with all new tests green
- [ ] `pool_deposit` event test finds `PoolDepositEvent` with correct depositor, pool_id, and amount topics
- [ ] `pool_withdraw` event test finds `PoolWithdrawEvent` with correct recipient, pool_id, and amount topics
- [ ] `get_following` and `get_followers` both return the expected addresses after a single `follow` call
- [ ] `get_following` and `get_followers` both return empty vecs after `unfollow`
- [ ] Double `follow` leaves both indexes at length 1
- [ ] `unfollow` on a non-existent relationship does not panic
- [ ] `run_e2e.sh` completes step 8 without errors when run against a local Stellar sandbox

Closes #137
Closes #138
Closes #144
Closes #145