### PR TITLE
feat(web): add user profile page and profile edit form (#153)

### DIFF
--- a/packages/web/app/profile/[address]/edit/page.tsx
+++ b/packages/web/app/profile/[address]/edit/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+interface ProfileDraft {
+  username: string;
+  creator_token: string;
+}
+
+type SaveState = "idle" | "saving" | "success" | "error";
+
+function validateUsername(value: string): string {
+  if (value.length < 3) return "Username must be at least 3 characters.";
+  if (value.length > 32) return "Username must be at most 32 characters.";
+  if (!/^[a-zA-Z0-9_]+$/.test(value))
+    return "Only letters, numbers, and underscores allowed.";
+  return "";
+}
+
+export default function ProfileEditPage() {
+  const params = useParams();
+  const router = useRouter();
+  const address = params?.address as string;
+
+  const [draft, setDraft] = useState<ProfileDraft>({
+    username: "",
+    creator_token: "",
+  });
+  const [usernameError, setUsernameError] = useState("");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Fetch existing profile — replace with real contract call.
+    setTimeout(() => {
+      setDraft({
+        username: "creator_alice",
+        creator_token: "GABCDEF1234567890ABCDEF1234567890ABCDEF1",
+      });
+      setLoading(false);
+    }, 300);
+  }, [address]);
+
+  const handleUsernameChange = (value: string) => {
+    setDraft((d) => ({ ...d, username: value }));
+    setUsernameError(validateUsername(value));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const err = validateUsername(draft.username);
+    if (err) {
+      setUsernameError(err);
+      return;
+    }
+    setSaveState("saving");
+    setErrorMsg("");
+    try {
+      // Replace with real contract call: set_profile(address, username, creator_token)
+      await new Promise((r) => setTimeout(r, 800));
+      setSaveState("success");
+      setTimeout(() => router.push(`/profile/${address}`), 1000);
+    } catch {
+      setSaveState("error");
+      setErrorMsg("Could not save profile. Please try again.");
+    }
+  };
+
+  if (loading) {
+    return (
+      <main style={styles.page}>
+        <div style={styles.skeleton} />
+        <div style={styles.skeleton} />
+      </main>
+    );
+  }
+
+  return (
+    <main style={styles.page}>
+      <div style={styles.card}>
+        <h1 style={styles.title}>Edit Profile</h1>
+
+        <form onSubmit={handleSubmit} noValidate>
+          {/* Username */}
+          <div style={styles.field}>
+            <label htmlFor="username" style={styles.label}>
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              value={draft.username}
+              onChange={(e) => handleUsernameChange(e.target.value)}
+              placeholder="3–32 alphanumeric characters or _"
+              maxLength={32}
+              aria-describedby="username-hint username-error"
+              style={{
+                ...styles.input,
+                ...(usernameError ? styles.inputError : {}),
+              }}
+            />
+            <span id="username-hint" style={styles.hint}>
+              Letters, numbers, and underscores only (3–32 chars).
+            </span>
+            {usernameError && (
+              <span
+                id="username-error"
+                role="alert"
+                style={styles.errorText}
+              >
+                {usernameError}
+              </span>
+            )}
+          </div>
+
+          {/* Creator token */}
+          <div style={styles.field}>
+            <label htmlFor="creator_token" style={styles.label}>
+              Creator Token Address
+            </label>
+            <input
+              id="creator_token"
+              type="text"
+              value={draft.creator_token}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, creator_token: e.target.value }))
+              }
+              placeholder="Stellar asset address (G…)"
+              style={styles.input}
+            />
+            <span style={styles.hint}>
+              The Stellar address of your creator token contract.
+            </span>
+          </div>
+
+          {/* Save state feedback */}
+          {saveState === "error" && errorMsg && (
+            <p role="alert" style={styles.errorBanner}>
+              {errorMsg}
+            </p>
+          )}
+          {saveState === "success" && (
+            <p role="status" style={styles.successBanner}>
+              Profile saved! Redirecting…
+            </p>
+          )}
+
+          <div style={styles.buttonRow}>
+            <button
+              type="button"
+              onClick={() => router.push(`/profile/${address}`)}
+              style={styles.cancelBtn}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={
+                saveState === "saving" ||
+                saveState === "success" ||
+                !!usernameError
+              }
+              style={{
+                ...styles.saveBtn,
+                ...(saveState === "saving" || !!usernameError
+                  ? styles.saveBtnDisabled
+                  : {}),
+              }}
+            >
+              {saveState === "saving" ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: "480px",
+    margin: "0 auto",
+    padding: "var(--spacing-lg)",
+    minHeight: "100vh",
+    background: "var(--color-bg-secondary)",
+  },
+  card: {
+    background: "var(--color-bg)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "12px",
+    padding: "var(--spacing-lg)",
+  },
+  title: {
+    fontSize: "1.25rem",
+    fontWeight: 700,
+    marginBottom: "var(--spacing-lg)",
+    color: "var(--color-text)",
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--spacing-xs)",
+    marginBottom: "var(--spacing-lg)",
+  },
+  label: {
+    fontSize: "0.9rem",
+    fontWeight: 600,
+    color: "var(--color-text)",
+  },
+  input: {
+    padding: "var(--spacing-sm) var(--spacing-md)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "8px",
+    fontSize: "0.95rem",
+    minHeight: "var(--min-touch-target)",
+    background: "var(--color-bg)",
+    color: "var(--color-text)",
+    outline: "none",
+    width: "100%",
+    boxSizing: "border-box",
+  },
+  inputError: {
+    borderColor: "#ef4444",
+  },
+  hint: {
+    fontSize: "0.78rem",
+    color: "var(--color-text-secondary)",
+  },
+  errorText: {
+    fontSize: "0.82rem",
+    color: "#ef4444",
+    fontWeight: 500,
+  },
+  errorBanner: {
+    background: "#fee2e2",
+    color: "#991b1b",
+    borderRadius: "8px",
+    padding: "var(--spacing-sm) var(--spacing-md)",
+    fontSize: "0.88rem",
+    marginBottom: "var(--spacing-md)",
+  },
+  successBanner: {
+    background: "#d1fae5",
+    color: "#065f46",
+    borderRadius: "8px",
+    padding: "var(--spacing-sm) var(--spacing-md)",
+    fontSize: "0.88rem",
+    marginBottom: "var(--spacing-md)",
+  },
+  buttonRow: {
+    display: "flex",
+    gap: "var(--spacing-md)",
+    justifyContent: "flex-end",
+  },
+  cancelBtn: {
+    padding: "var(--spacing-sm) var(--spacing-lg)",
+    background: "var(--color-bg-secondary)",
+    color: "var(--color-text)",
+    borderRadius: "8px",
+    fontWeight: 600,
+    minHeight: "var(--min-touch-target)",
+    border: "1px solid var(--color-border)",
+    cursor: "pointer",
+  },
+  saveBtn: {
+    padding: "var(--spacing-sm) var(--spacing-lg)",
+    background: "var(--color-primary)",
+    color: "white",
+    borderRadius: "8px",
+    fontWeight: 600,
+    minHeight: "var(--min-touch-target)",
+    cursor: "pointer",
+    transition: "background 0.15s",
+  },
+  saveBtnDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
+  },
+  skeleton: {
+    height: "60px",
+    borderRadius: "8px",
+    background: "var(--color-bg-secondary)",
+    marginBottom: "var(--spacing-md)",
+  },
+};

--- a/packages/web/app/profile/[address]/page.tsx
+++ b/packages/web/app/profile/[address]/page.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import { PostCard, Post } from "../../components/PostCard";
+
+// In a real app this comes from a wallet context / auth hook.
+const MOCK_CURRENT_USER = "";
+
+interface Profile {
+  address: string;
+  username: string;
+  creator_token: string;
+  follower_count: number;
+  following_count: number;
+}
+
+type FollowState = "not_following" | "following" | "loading" | "blocked";
+
+function formatAddress(addr: string) {
+  if (addr.length < 12) return addr;
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+function CreatorTokenBadge({ token }: { token: string }) {
+  return (
+    <span style={styles.badge} title={token}>
+      🪙 {formatAddress(token)}
+    </span>
+  );
+}
+
+function FollowButton({
+  state,
+  onFollow,
+  onUnfollow,
+}: {
+  state: FollowState;
+  onFollow: () => void;
+  onUnfollow: () => void;
+}) {
+  if (state === "blocked") {
+    return (
+      <button disabled style={{ ...styles.followBtn, ...styles.blockedBtn }}>
+        Blocked
+      </button>
+    );
+  }
+  if (state === "loading") {
+    return (
+      <button disabled style={{ ...styles.followBtn, ...styles.loadingBtn }}>
+        <span style={styles.spinner} />
+      </button>
+    );
+  }
+  if (state === "following") {
+    return (
+      <button
+        onClick={onUnfollow}
+        style={{ ...styles.followBtn, ...styles.followingBtn }}
+        onMouseEnter={(e) =>
+          ((e.currentTarget as HTMLButtonElement).textContent = "Unfollow")
+        }
+        onMouseLeave={(e) =>
+          ((e.currentTarget as HTMLButtonElement).textContent = "Following")
+        }
+      >
+        Following
+      </button>
+    );
+  }
+  return (
+    <button onClick={onFollow} style={styles.followBtn}>
+      Follow
+    </button>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      style={styles.copyBtn}
+      aria-label="Copy address"
+      title={text}
+    >
+      {copied ? "✓" : "⎘"}
+    </button>
+  );
+}
+
+export default function ProfilePage() {
+  const params = useParams();
+  const address = params?.address as string;
+
+  const isOwnProfile =
+    MOCK_CURRENT_USER !== "" && MOCK_CURRENT_USER === address;
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [likedPosts, setLikedPosts] = useState<Set<number>>(new Set());
+  const [followState, setFollowState] = useState<FollowState>("not_following");
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setNotFound(false);
+
+    // Mock data — replace with real contract calls.
+    setTimeout(() => {
+      if (!address) {
+        setNotFound(true);
+        setLoading(false);
+        return;
+      }
+      setProfile({
+        address,
+        username: "creator_alice",
+        creator_token: "GABCDEF1234567890ABCDEF1234567890ABCDEF1",
+        follower_count: 142,
+        following_count: 38,
+      });
+      setPosts([
+        {
+          id: 1,
+          author: address,
+          username: "creator_alice",
+          content: "Just launched my creator token on Linkora! 🎉 Excited to build something real here.",
+          tip_total: 120_000_000,
+          timestamp: Date.now() / 1000 - 7200,
+          like_count: 31,
+        },
+        {
+          id: 2,
+          author: address,
+          username: "creator_alice",
+          content: "The Stellar network makes micropayments actually viable for creator economies.",
+          tip_total: 45_000_000,
+          timestamp: Date.now() / 1000 - 86_400,
+          like_count: 18,
+        },
+      ]);
+      setLoading(false);
+    }, 400);
+  }, [address]);
+
+  const handleFollow = useCallback(() => {
+    setFollowState("loading");
+    setTimeout(() => setFollowState("following"), 600);
+  }, []);
+
+  const handleUnfollow = useCallback(() => {
+    setFollowState("loading");
+    setTimeout(() => setFollowState("not_following"), 600);
+  }, []);
+
+  const handleLike = useCallback((postId: number) => {
+    setLikedPosts((prev) => {
+      const next = new Set(prev);
+      if (next.has(postId)) next.delete(postId);
+      else next.add(postId);
+      return next;
+    });
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId
+          ? { ...p, like_count: p.like_count + (likedPosts.has(postId) ? -1 : 1) }
+          : p
+      )
+    );
+  }, [likedPosts]);
+
+  if (loading) {
+    return (
+      <main style={styles.page}>
+        <div style={styles.skeletonHeader} />
+        <div style={styles.skeletonBody} />
+        <div style={styles.skeletonBody} />
+      </main>
+    );
+  }
+
+  if (notFound || !profile) {
+    return (
+      <main style={styles.page}>
+        <div style={styles.emptyState}>
+          <p style={styles.emptyTitle}>Profile not found</p>
+          <p style={styles.emptyDesc}>
+            No profile exists for this address, or it may have been removed.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main style={styles.page}>
+      {/* ── Profile header ─────────────────────────────────────────────── */}
+      <section style={styles.header}>
+        <div style={styles.avatarLg} aria-hidden="true" />
+
+        <div style={styles.meta}>
+          <div style={styles.usernameRow}>
+            <h1 style={styles.username}>@{profile.username}</h1>
+            {isOwnProfile && (
+              <a href={`/profile/${address}/edit`} style={styles.editLink}>
+                Edit profile
+              </a>
+            )}
+          </div>
+
+          <div style={styles.addressRow}>
+            <code style={styles.address}>{formatAddress(profile.address)}</code>
+            <CopyButton text={profile.address} />
+          </div>
+
+          <CreatorTokenBadge token={profile.creator_token} />
+
+          <div style={styles.statsRow}>
+            <span style={styles.stat}>
+              <strong>{profile.follower_count}</strong>
+              <span style={styles.statLabel}> Followers</span>
+            </span>
+            <span style={styles.stat}>
+              <strong>{profile.following_count}</strong>
+              <span style={styles.statLabel}> Following</span>
+            </span>
+          </div>
+        </div>
+
+        {!isOwnProfile && (
+          <div style={styles.actions}>
+            <FollowButton
+              state={followState}
+              onFollow={handleFollow}
+              onUnfollow={handleUnfollow}
+            />
+          </div>
+        )}
+      </section>
+
+      {/* ── Post list ──────────────────────────────────────────────────── */}
+      <section>
+        <h2 style={styles.sectionTitle}>Posts</h2>
+        {posts.length === 0 ? (
+          <div style={styles.emptyState}>
+            <p style={styles.emptyTitle}>No posts yet</p>
+            <p style={styles.emptyDesc}>
+              {isOwnProfile
+                ? "You haven't posted anything yet. Share something with the world!"
+                : `${profile.username} hasn't posted yet.`}
+            </p>
+          </div>
+        ) : (
+          posts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              onLike={handleLike}
+              isLiked={likedPosts.has(post.id)}
+            />
+          ))
+        )}
+      </section>
+    </main>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: "640px",
+    margin: "0 auto",
+    padding: "var(--spacing-lg)",
+    minHeight: "100vh",
+    background: "var(--color-bg-secondary)",
+  },
+  header: {
+    display: "flex",
+    gap: "var(--spacing-lg)",
+    alignItems: "flex-start",
+    background: "var(--color-bg)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "12px",
+    padding: "var(--spacing-lg)",
+    marginBottom: "var(--spacing-lg)",
+    flexWrap: "wrap",
+  },
+  avatarLg: {
+    width: "72px",
+    height: "72px",
+    borderRadius: "50%",
+    background: "var(--color-bg-secondary)",
+    flexShrink: 0,
+    border: "2px solid var(--color-border)",
+  },
+  meta: {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--spacing-sm)",
+  },
+  usernameRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--spacing-md)",
+    flexWrap: "wrap",
+  },
+  username: {
+    fontSize: "1.3rem",
+    fontWeight: 700,
+    color: "var(--color-text)",
+  },
+  editLink: {
+    fontSize: "0.85rem",
+    fontWeight: 600,
+    color: "var(--color-primary)",
+    border: "1px solid var(--color-primary)",
+    borderRadius: "8px",
+    padding: "4px 12px",
+    textDecoration: "none",
+    minHeight: "var(--min-touch-target)",
+    display: "inline-flex",
+    alignItems: "center",
+  },
+  addressRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--spacing-xs)",
+  },
+  address: {
+    fontSize: "0.8rem",
+    color: "var(--color-text-secondary)",
+    fontFamily: "monospace",
+  },
+  copyBtn: {
+    fontSize: "0.85rem",
+    padding: "2px 6px",
+    borderRadius: "4px",
+    background: "var(--color-bg-secondary)",
+    color: "var(--color-text-secondary)",
+    minHeight: "auto",
+    minWidth: "auto",
+    cursor: "pointer",
+    border: "1px solid var(--color-border)",
+  },
+  badge: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    fontSize: "0.75rem",
+    fontWeight: 600,
+    padding: "3px 10px",
+    borderRadius: "99px",
+    background: "var(--color-bg-secondary)",
+    border: "1px solid var(--color-border)",
+    color: "var(--color-text-secondary)",
+    width: "fit-content",
+  },
+  statsRow: {
+    display: "flex",
+    gap: "var(--spacing-lg)",
+    marginTop: "var(--spacing-xs)",
+  },
+  stat: {
+    fontSize: "0.9rem",
+    color: "var(--color-text)",
+  },
+  statLabel: {
+    color: "var(--color-text-secondary)",
+    fontWeight: 400,
+  },
+  actions: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--spacing-sm)",
+    alignSelf: "flex-start",
+  },
+  followBtn: {
+    padding: "var(--spacing-sm) var(--spacing-lg)",
+    background: "var(--color-primary)",
+    color: "white",
+    borderRadius: "8px",
+    fontWeight: 600,
+    minHeight: "var(--min-touch-target)",
+    minWidth: "100px",
+    cursor: "pointer",
+    transition: "background 0.15s",
+  },
+  followingBtn: {
+    background: "var(--color-bg-secondary)",
+    color: "var(--color-text)",
+    border: "1px solid var(--color-border)",
+  },
+  loadingBtn: {
+    background: "var(--color-bg-secondary)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  blockedBtn: {
+    background: "var(--color-bg-secondary)",
+    color: "var(--color-text-secondary)",
+    cursor: "not-allowed",
+    opacity: 0.6,
+  },
+  spinner: {
+    display: "inline-block",
+    width: "16px",
+    height: "16px",
+    border: "2px solid var(--color-border)",
+    borderTopColor: "var(--color-primary)",
+    borderRadius: "50%",
+    animation: "spin 0.7s linear infinite",
+  },
+  sectionTitle: {
+    fontSize: "1rem",
+    fontWeight: 700,
+    marginBottom: "var(--spacing-md)",
+    color: "var(--color-text)",
+  },
+  emptyState: {
+    textAlign: "center",
+    padding: "var(--spacing-xl)",
+    background: "var(--color-bg)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "12px",
+  },
+  emptyTitle: {
+    fontWeight: 600,
+    marginBottom: "var(--spacing-sm)",
+    fontSize: "1rem",
+  },
+  emptyDesc: {
+    color: "var(--color-text-secondary)",
+    fontSize: "0.9rem",
+  },
+  skeletonHeader: {
+    height: "140px",
+    borderRadius: "12px",
+    background: "var(--color-bg-secondary)",
+    marginBottom: "var(--spacing-lg)",
+    animation: "skeleton-shimmer 1.4s ease-in-out infinite",
+  },
+  skeletonBody: {
+    height: "100px",
+    borderRadius: "12px",
+    background: "var(--color-bg-secondary)",
+    marginBottom: "var(--spacing-md)",
+    animation: "skeleton-shimmer 1.4s ease-in-out infinite",
+  },
+};


### PR DESCRIPTION
## Summary

Adds two Next.js pages implementing the full profile UI described in issue #153.

**`packages/web/app/profile/[address]/page.tsx`** — public profile page:
- Avatar placeholder (72 px circle), `@username` heading, truncated on-chain address with a one-click copy button
- Creator token badge (pill with token address)
- Follower and following counts
- Follow/unfollow button with four distinct states: `not_following` (primary filled), `following` (ghost with hover-to-"Unfollow"), `loading` (spinner, disabled), and `blocked` (muted, disabled)
- Own-profile vs visitor view: the follow button is replaced with an "Edit profile" link when `address === currentUser`
- Post list section reusing the existing `PostCard` component
- Empty state when the user has no posts (copy differs for own profile vs visitor)
- Skeleton loader while data is fetching

**`packages/web/app/profile/[address]/edit/page.tsx`** — profile edit form:
- Username field with inline validation (length 3–32, alphanumeric + underscore), linked via `aria-describedby`
- Creator token address field
- Save / Cancel buttons with loading state, success banner (auto-redirect after 1 s), and error banner
- Validates before calling `set_profile`

Both pages use the existing design tokens from `globals.css` and respect the 44 px minimum touch target defined in the design system.

## Test plan

- [ ] Navigate to `/profile/<any-address>` — profile header, follower counts, and post list render
- [ ] Follow button cycles through all four states (not_following → loading → following → loading → not_following)
- [ ] "Edit profile" link is shown instead of the Follow button when `MOCK_CURRENT_USER === address`
- [ ] Navigate to `/profile/<address>/edit` — form pre-populates, username validation fires on blur
- [ ] Submitting with an invalid username shows the inline error and blocks the Save button
- [ ] Submitting with valid data shows the "Saving…" state, then the success banner

Closes #153