### PR TITLE
feat: add env var config for RPC URL, network, and contract ID

### DIFF
--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,8 @@
+# Soroban RPC endpoint
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Network passphrase
+NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Deployed Linkora contract ID
+NEXT_PUBLIC_CONTRACT_ID=

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -1,2 +1,3 @@
 
 .next/
+.env*.local

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -38,6 +38,24 @@ pnpm --filter web build
 pnpm --filter web lint
 ```
 
+## Environment Setup
+
+Copy the example file and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Soroban RPC endpoint (e.g. `https://soroban-testnet.stellar.org`) |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Stellar network passphrase |
+| `NEXT_PUBLIC_CONTRACT_ID` | Deployed Linkora contract ID |
+
+The app will throw an error at startup if any of these variables are missing.
+
+`.env.example` is pre-filled for Testnet. For local sandbox or Mainnet, update the values accordingly. Never commit `.env.local` or any `.env*.local` file.
+
 ## Notes
 
 - This scaffold intentionally keeps the first page minimal.

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,0 +1,13 @@
+const required = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+export const config = {
+  sorobanRpcUrl: required("NEXT_PUBLIC_SOROBAN_RPC_URL"),
+  networkPassphrase: required("NEXT_PUBLIC_NETWORK_PASSPHRASE"),
+  contractId: required("NEXT_PUBLIC_CONTRACT_ID"),
+} as const;


### PR DESCRIPTION
## Summary

Adds environment variable configuration for the web frontend's Soroban connection. Creates packages/web/.env.example with Testnet defaults for 
NEXT_PUBLIC_SOROBAN_RPC_URL, NEXT_PUBLIC_NETWORK_PASSPHRASE, and NEXT_PUBLIC_CONTRACT_ID. Adds packages/web/src/config.ts which reads and 
validates these variables at startup, failing fast with a clear error if any are missing. Updates .gitignore to exclude .env*.local and adds 
environment setup instructions to packages/web/README.md.

## Checklist

- [ ] Tests added or updated for changed behaviour
- [x] Existing tests pass (cargo test)
- [x] Changes are focused — one concern per PR
- [ ] If a contract function was added or changed, the README API table is updated
- [x] No unresolved merge conflicts

closes #101
