### PR TITLE
docs/feat: governance, contract security review, indexer rate limiting, SDK docs

### DIFF
--- a/.github/workflows/sdk-docs.yml
+++ b/.github/workflows/sdk-docs.yml
@@ -1,0 +1,59 @@
+name: SDK Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/sdk/src/**"
+      - "packages/sdk/package.json"
+      - "packages/sdk/tsconfig.json"
+      - ".github/workflows/sdk-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    name: Build TypeDoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate SDK docs
+        run: pnpm --filter sdk docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/sdk/docs
+
+  deploy-docs:
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,3 +289,7 @@ The `.github/CODEOWNERS` file maps directories to their maintainers:
 ## Security
 
 If you discover a security vulnerability, please review our [Security Policy](SECURITY.md) for responsible disclosure guidelines. Do not open public issues for security concerns.
+
+## Governance
+
+Project roles, decision-making processes, and the path to becoming a maintainer are described in [docs/GOVERNANCE.md](docs/GOVERNANCE.md).

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,122 @@
+# Linkora-Social Governance
+
+This document describes how decisions are made in the Linkora-Social project, how the project is maintained, and how community members can take on greater responsibility.
+
+## Table of Contents
+
+1. [Project Roles](#1-project-roles)
+2. [Decision-Making](#2-decision-making)
+3. [Becoming a Maintainer](#3-becoming-a-maintainer)
+4. [Code of Conduct](#4-code-of-conduct)
+5. [Communication Channels](#5-communication-channels)
+
+---
+
+## 1. Project Roles
+
+### Contributor
+
+Anyone who submits a bug report, feature request, or pull request. Contributors do not require any formal recognition or invitation — opening an issue or PR immediately makes you a contributor.
+
+**Responsibilities:**
+- Follow the contributing guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)
+- Adhere to the [Code of Conduct](#4-code-of-conduct)
+- Respond to review feedback on open PRs in a timely manner
+
+### Reviewer
+
+A contributor who has demonstrated sustained, high-quality contributions and is invited to review pull requests. Reviewers can approve PRs but cannot merge without a maintainer's final approval.
+
+**Responsibilities:**
+- Provide constructive, timely code reviews
+- Flag security concerns or breaking changes before approval
+- Help triage issues and answer community questions
+
+### Maintainer
+
+Maintainers have write access to the repository and are responsible for the long-term health of the codebase. They merge pull requests, cut releases, and set the technical direction.
+
+**Current Maintainers:** [@Epta-Node](https://github.com/Epta-Node)
+
+**Responsibilities:**
+- Review and merge approved pull requests
+- Enforce branch protection and CI requirements
+- Manage the release process (see `CONTRIBUTING.md` § Release Process)
+- Uphold the Code of Conduct, including enforcement decisions
+
+---
+
+## 2. Decision-Making
+
+### Everyday Decisions
+
+Most decisions — bug fixes, documentation updates, minor features — follow standard GitHub flow:
+
+1. An issue is opened describing the change.
+2. A contributor opens a PR referencing the issue.
+3. At least one reviewer approves the PR.
+4. A maintainer performs a final review and merges.
+
+No formal vote is required for changes that do not affect the public contract interface, storage layout, event schema, or governance structure.
+
+### Significant Changes
+
+The following changes require explicit maintainer consensus (at minimum two maintainer approvals) before merging:
+
+- Changes to the public Soroban contract interface (function signatures, removed functions)
+- Changes to the on-chain storage key layout or contracttype definitions
+- Changes to the event schema (`#[contractevent]` structs)
+- Changes to the fee model or treasury address logic
+- Contract upgrade proposals (`upgrade()` function)
+- Changes to this governance document
+
+For significant changes, open an issue with the label `proposal` and allow at least **5 business days** for maintainer discussion before proceeding.
+
+### Breaking Changes
+
+Breaking changes (major version bumps per the versioning policy in `CONTRIBUTING.md`) must be announced in the community Telegram channel at least **2 weeks** before the target merge date and must include a migration guide in the PR description.
+
+### Disputes
+
+If contributors cannot reach consensus through normal review, any maintainer may call for a time-boxed discussion (72 hours). If consensus is still not reached, the decision rests with the core maintainers by simple majority.
+
+---
+
+## 3. Becoming a Maintainer
+
+There is no fixed timeline or point system. Maintainers are invited based on demonstrated judgment and consistent positive impact on the project. Typical indicators include:
+
+- Multiple merged PRs of increasing complexity
+- High-quality, constructive code reviews
+- Active participation in issue triage or community support
+- Understanding of Soroban smart contract security and the Linkora data model
+
+**Process:**
+1. A current maintainer nominates the candidate in the private maintainer channel.
+2. All current maintainers discuss and vote (simple majority, 5-day window).
+3. If approved, the candidate is offered write access and added to `CODEOWNERS`.
+4. The candidate's name is added to the Maintainers list in this document.
+
+Maintainer status is voluntary. A maintainer who is no longer active may step down at any time by notifying the team. After 6 months of inactivity with no response to pings, maintainer access may be revoked by the remaining maintainers.
+
+---
+
+## 4. Code of Conduct
+
+All participants in the Linkora-Social community — including contributors, reviewers, maintainers, and anyone engaging in the project's issue tracker, pull requests, or communication channels — are expected to follow the project Code of Conduct.
+
+The full Code of Conduct is available at [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) (if not yet present, the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) applies by default).
+
+**Enforcement:** Violations should be reported to the maintainer team via a private message on Telegram (see below) or by emailing a maintainer directly. Reports are treated confidentially. Maintainers who are the subject of a report recuse themselves from the decision.
+
+---
+
+## 5. Communication Channels
+
+| Channel | Purpose |
+|---------|---------|
+| [GitHub Issues](https://github.com/Epta-Node/Linkora-social/issues) | Bug reports, feature requests, and formal proposals |
+| [GitHub Discussions](https://github.com/Epta-Node/Linkora-social/discussions) | Open-ended questions and community conversation |
+| [Telegram Community](https://t.me/+13csp8G4ccRhY2Zk) | Real-time discussion, announcements, and breaking-change notices |
+
+For security disclosures, see [SECURITY.md](../SECURITY.md) — do not use public channels for vulnerability reports.

--- a/docs/indexer/API.md
+++ b/docs/indexer/API.md
@@ -57,3 +57,55 @@ Search posts by keyword content.
 - `INVALID_QUERY`: Query parameter is missing or invalid
 - `LIMIT_EXCEEDED`: Limit parameter exceeds maximum allowed value
 - `INTERNAL_ERROR`: Server error occurred during search
+
+---
+
+## Rate Limiting
+
+All `/api` endpoints are subject to IP-based rate limiting.
+
+### Default Limits
+
+| Parameter | Default | Environment variable |
+|-----------|---------|----------------------|
+| Window | 60 seconds | `RATE_LIMIT_WINDOW_MS` |
+| Max requests per window | 100 | `RATE_LIMIT_MAX` |
+
+### Rate Limit Response
+
+When the limit is exceeded the server returns **HTTP 429 Too Many Requests** with a `Retry-After` header indicating how many seconds to wait before retrying.
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+Content-Type: application/json
+```
+
+```json
+{
+  "error": "Too many requests. Please retry after the indicated delay.",
+  "code": "RATE_LIMIT_EXCEEDED",
+  "retryAfterSeconds": 60
+}
+```
+
+### Standard Rate-Limit Headers
+
+Responses also include `RateLimit-*` headers (RFC 9110 draft-7) on every request:
+
+| Header | Description |
+|--------|-------------|
+| `RateLimit-Limit` | Maximum requests allowed per window |
+| `RateLimit-Remaining` | Requests remaining in the current window |
+| `RateLimit-Reset` | Unix timestamp when the current window resets |
+
+### Configuration
+
+Override defaults via environment variables before starting the indexer service:
+
+```bash
+# Allow 200 requests per 2-minute window
+RATE_LIMIT_MAX=200 RATE_LIMIT_WINDOW_MS=120000 node dist/index.js
+```
+
+Rate limiting is applied per originating IP address. When the service runs behind a reverse proxy, set `trust proxy` in the Express configuration and ensure only your load-balancer can set the `X-Forwarded-For` header.

--- a/docs/security/CONTRACT_REVIEW.md
+++ b/docs/security/CONTRACT_REVIEW.md
@@ -1,0 +1,226 @@
+# LinkoraContract Security Review
+
+**Contract:** `packages/contracts/contracts/linkora-contracts/src/lib.rs`  
+**Review Date:** 2025-05-26  
+**Reviewer:** Community security review (open-source week)  
+**Scope:** Full review of `LinkoraContract` — profiles, social graph, posts, reactions, tipping, community pools, upgradability.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 1 |
+| Medium | 3 |
+| Low | 3 |
+| Informational | 3 |
+
+No critical vulnerabilities were identified. One high-severity finding relates to integer overflow in the fee calculation path. The remaining findings are medium or lower severity.
+
+---
+
+## Findings
+
+### [HIGH-01] Integer overflow in fee calculation
+
+**Location:** `lib.rs`, `tip()` function, line ~715  
+**Severity:** High
+
+**Description:**  
+The fee calculation performs a direct multiplication before division:
+
+```rust
+let fee_amount = (amount * fee_bps as i128) / 10_000;
+```
+
+`i128` can hold values up to approximately `1.7 × 10^38`. However, `amount` is user-controlled (passed in as `i128`) and `fee_bps` can be up to `10_000`. If `amount` approaches `i128::MAX / 10_000` (~`1.7 × 10^34`), the multiplication `amount * fee_bps as i128` overflows in debug builds and wraps silently in release builds. A wrapped fee could be negative, allowing an attacker to receive more than they tipped.
+
+In practice, token balances on Stellar are bounded by the token contract's supply, making extremely large `amount` values unlikely for most tokens. However, the contract places no upper bound on `amount`, and a malicious or custom token could produce an exploit path.
+
+**Recommendation:**  
+Use a checked multiplication and handle overflow explicitly:
+
+```rust
+let fee_amount = amount
+    .checked_mul(fee_bps as i128)
+    .expect("tip amount overflow")
+    / 10_000;
+```
+
+Alternatively, cap `amount` to a protocol maximum (e.g., `i64::MAX`) and document the invariant.
+
+---
+
+### [MED-01] Unbounded `Vec<Address>` growth in follow/follower lists
+
+**Location:** `lib.rs`, `follow()` and `unfollow()` functions  
+**Severity:** Medium
+
+**Description:**  
+Following and follower lists are stored as `Vec<Address>` in persistent storage. There is no cap on how many addresses can be added to these lists. An attacker can create many accounts and have them all follow a single target address, growing the follower `Vec` arbitrarily. Because every `follow()` call loads the entire list, serializes the updated list, and writes it back, storage size and CPU costs grow linearly with follower count.
+
+On Soroban, large persistent entries incur higher ledger entry fees and may eventually exceed the maximum contract data entry size, making the affected account's follow/follower data permanently inaccessible.
+
+**Recommendation:**  
+Introduce a maximum per-user follow/follower count constant (e.g., `MAX_FOLLOWS: u32 = 5_000`) and assert it before appending to either list. Alternatively, migrate to a sparse key-per-pair design (`StorageKey::FollowEdge(follower, followee)`) that avoids loading the entire list on every call.
+
+---
+
+### [MED-02] `get_followers` allows `limit = 0`; inconsistent with `get_following`
+
+**Location:** `lib.rs`, lines ~469 and ~486  
+**Severity:** Medium
+
+**Description:**  
+`get_following` validates:
+
+```rust
+assert!(limit > 0 && limit <= MAX_PAGINATION_LIMIT, "limit must be between 1 and 50");
+```
+
+But `get_followers` only validates:
+
+```rust
+assert!(limit <= MAX_PAGE_LIMIT, "limit exceeded");
+```
+
+A call to `get_followers` with `limit = 0` passes validation. The `paginate` helper correctly returns an empty `Vec` for `limit = 0`, so there is no functional exploit, but the inconsistency creates a confusing API surface and may cause unexpected empty responses for callers who forget to set a non-zero limit.
+
+**Recommendation:**  
+Align `get_followers` with `get_following`:
+
+```rust
+assert!(limit > 0 && limit <= MAX_PAGE_LIMIT, "limit must be between 1 and 50");
+```
+
+---
+
+### [MED-03] `pool_withdraw` duplicate-signer check missing
+
+**Location:** `lib.rs`, `pool_withdraw()` function, line ~823  
+**Severity:** Medium
+
+**Description:**  
+The `pool_withdraw` function checks that the number of signers meets the threshold and that each signer is in the pool's admin list, but it does not verify that the same address does not appear more than once in the `signers` argument. A pool admin could pass their address `threshold` times in the `signers` Vec and satisfy the M-of-N requirement alone.
+
+```rust
+// No deduplication check
+assert!(signers.len() >= pool.threshold, "insufficient signers");
+for signer in signers.iter() {
+    assert!(pool.admins.iter().any(|x| x == signer), "unauthorized signer");
+    signer.require_auth();
+}
+```
+
+While `require_auth()` is called for each entry, Soroban's auth model counts repeated auths for the same address as equivalent to a single auth, so a single admin can drain a pool that requires `threshold > 1` approvals by listing their address `threshold` times.
+
+**Recommendation:**  
+Deduplicate `signers` before the threshold check, or track unique authenticated addresses in a local `Map<Address, bool>`:
+
+```rust
+let mut seen: Map<Address, bool> = Map::new(&env);
+let mut unique_count: u32 = 0;
+for signer in signers.iter() {
+    assert!(pool.admins.iter().any(|x| x == signer), "unauthorized signer");
+    signer.require_auth();
+    if !seen.contains_key(signer.clone()) {
+        seen.set(signer, true);
+        unique_count += 1;
+    }
+}
+assert!(unique_count >= pool.threshold, "insufficient unique signers");
+```
+
+The same issue applies to `add_pool_admin`, `remove_pool_admin`, and `update_pool_threshold`.
+
+---
+
+### [LOW-01] `LEDGER_THRESHOLD` is nearly equal to `LEDGER_BUMP`
+
+**Location:** `lib.rs`, lines ~38–39  
+**Severity:** Low
+
+**Description:**  
+
+```rust
+const LEDGER_BUMP: u32 = 535_000;
+const LEDGER_THRESHOLD: u32 = 535_000 - 100;
+```
+
+The lazy-extension pattern is intended to avoid bumping TTL on every read by only extending when the remaining TTL falls below `LEDGER_THRESHOLD`. With a gap of only 100 ledgers (~8 minutes at 5 s/ledger) between bump and threshold, the TTL is extended on nearly every access, negating the lazy optimization and paying the `extend_ttl` fee unnecessarily often.
+
+**Recommendation:**  
+Set `LEDGER_THRESHOLD` to roughly half of `LEDGER_BUMP` (e.g., `267_500`) so that the extension is triggered only when the entry is at genuine risk of expiry:
+
+```rust
+const LEDGER_BUMP: u32 = 535_000;       // ~30 days
+const LEDGER_THRESHOLD: u32 = 267_500;  // extend when < ~15 days remain
+```
+
+---
+
+### [LOW-02] `set_fee` and `set_treasury` emit no events
+
+**Location:** `lib.rs`, `set_fee()` and `set_treasury()`  
+**Severity:** Low
+
+**Description:**  
+These admin functions silently change the fee rate and treasury address. Off-chain indexers and users have no way to detect that the fee changed or that treasury proceeds are being redirected to a new address without polling the contract state.
+
+**Recommendation:**  
+Emit a `FeeChangedEvent` and `TreasuryChangedEvent` (analogous to the existing `ContractUpgraded` event) to make these admin actions auditable on-chain.
+
+---
+
+### [LOW-03] `tip_total` on `Post` tracks gross tip, not net
+
+**Location:** `lib.rs`, `tip()` function  
+**Severity:** Low
+
+**Description:**  
+`post.tip_total += amount;` increments by the gross tip amount, including the portion deducted as a fee and sent to treasury. The field is named `tip_total` without clarifying whether it represents gross or net value, which may mislead integrators who assume it equals the amount the author actually received.
+
+**Recommendation:**  
+Either rename the field to `tip_total_gross`, or change the increment to `post.tip_total += author_amount;` and document the semantics clearly in a Rust doc comment.
+
+---
+
+### [INFO-01] No admin-transfer function
+
+**Location:** `lib.rs` — admin management  
+**Severity:** Informational
+
+**Description:**  
+There is no `transfer_admin` or `set_admin` function. Once the contract is deployed, the admin address is fixed. If the admin key is lost or compromised, there is no recovery path short of a contract upgrade.
+
+**Note:** This is a design choice, not necessarily a bug. However, projects that need key rotation should add a two-step admin transfer (propose + accept) to avoid accidentally locking the contract to an address that cannot sign.
+
+---
+
+### [INFO-02] `initialize` uses panic rather than an error type
+
+**Location:** `lib.rs`, `initialize()`  
+**Severity:** Informational
+
+**Description:**  
+`initialize` panics with a string if called more than once. Soroban best practice is to return a typed error (via `#[contracterror]`) for precondition failures so that callers can distinguish error cases without parsing panic messages.
+
+---
+
+### [INFO-03] `upgrade()` does not validate new WASM hash
+
+**Location:** `lib.rs`, `upgrade()`  
+**Severity:** Informational
+
+**Description:**  
+The `upgrade` function accepts any `BytesN<32>` as the new WASM hash without verifying that a contract with that hash has been uploaded to the network. If the hash does not correspond to an uploaded WASM, `update_current_contract_wasm` will panic and the transaction will fail, but the error message will be opaque. Documenting this precondition in a Rust doc comment would help integrators avoid confusing deployment failures.
+
+---
+
+## Out of Scope
+
+- Token contract security (the `token::Client` calls trust the token passed by the caller; accepting arbitrary token addresses is an intended design choice for multi-token support, but callers should be aware that malicious token contracts can reenter or behave unexpectedly)
+- Off-chain indexer security
+- Frontend security

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,61 @@
 
 Typed TypeScript client for `LinkoraContract`, generated from the compiled contract WASM using `stellar contract bindings typescript`.
 
+## Quick Start
+
+### 1. Install
+
+```bash
+pnpm add sdk
+```
+
+### 2. Instantiate the client
+
+```ts
+import { Client } from "sdk";
+
+const client = new Client({
+  contractId: "C...",          // deployed LinkoraContract address
+  networkPassphrase: "Test SDF Network ; September 2015",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+});
+```
+
+### 3. Call contract functions
+
+```ts
+// Read a post
+const post = await client.get_post({ id: 1n });
+console.log(post.result);
+
+// Create a post (requires auth)
+const tx = await client.create_post(
+  { author: keypair.publicKey(), content: "Hello Linkora!" },
+  { fee: 100 }
+);
+await tx.signAndSend({ signTransaction: keypair.sign.bind(keypair) });
+```
+
+### 4. Simulate before sending
+
+```ts
+// Simulate to estimate fees before committing
+const simResult = await client.tip(
+  { tipper: myAddress, post_id: 1n, token: xlmAddress, amount: 1_000_000n },
+  { simulate: true }
+);
+console.log("estimated fee:", simResult.simulationData?.minResourceFee);
+```
+
+## API Reference
+
+Full API documentation is published to GitHub Pages. Run locally with:
+
+```bash
+pnpm docs
+# Opens packages/sdk/docs/index.html
+```
+
 ## Regenerating the client
 
 Run this after every contract change:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "main": "./src/index.ts",
   "scripts": {
-    "build": "echo \"Run generate.sh to regenerate the client from the contract WASM\""
+    "build": "echo \"Run generate.sh to regenerate the client from the contract WASM\"",
+    "docs": "typedoc --out docs src/index.ts --tsconfig tsconfig.json"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.3.0"
   },
   "devDependencies": {
+    "typedoc": "^0.26.11",
     "typescript": "^5.8.3"
   }
 }

--- a/services/indexer/package.json
+++ b/services/indexer/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@linkora/indexer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Off-chain indexer service for Linkora social contract events",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.0",
+    "typescript": "^5.8.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/services/indexer/src/api/index.ts
+++ b/services/indexer/src/api/index.ts
@@ -1,0 +1,149 @@
+import express, { Request, Response, NextFunction } from "express";
+import rateLimit from "express-rate-limit";
+
+// ── Rate-limit configuration (all values are env-overridable) ────────────────
+
+const RATE_LIMIT_WINDOW_MS = parseInt(
+  process.env.RATE_LIMIT_WINDOW_MS ?? "60000",
+  10
+);
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX ?? "100", 10);
+
+// ── Rate limiter middleware ───────────────────────────────────────────────────
+
+const apiLimiter = rateLimit({
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  max: RATE_LIMIT_MAX,
+  standardHeaders: "draft-7", // Sends RateLimit-* headers (RFC 9110 draft-7)
+  legacyHeaders: false,
+  keyGenerator: (req: Request): string => {
+    // Respect X-Forwarded-For when running behind a trusted reverse proxy.
+    // In production, set `app.set("trust proxy", 1)` and ensure only your
+    // load-balancer can set this header.
+    const forwarded = req.headers["x-forwarded-for"];
+    if (typeof forwarded === "string") {
+      return forwarded.split(",")[0].trim();
+    }
+    return req.ip ?? "unknown";
+  },
+  handler: (req: Request, res: Response): void => {
+    const retryAfter = Math.ceil(RATE_LIMIT_WINDOW_MS / 1000);
+    res
+      .status(429)
+      .set("Retry-After", String(retryAfter))
+      .json({
+        error: "Too many requests. Please retry after the indicated delay.",
+        code: "RATE_LIMIT_EXCEEDED",
+        retryAfterSeconds: retryAfter,
+      });
+  },
+});
+
+// ── Express app ───────────────────────────────────────────────────────────────
+
+const app = express();
+app.use(express.json());
+
+// Apply rate limiting to all /api routes.
+app.use("/api", apiLimiter);
+
+// ── Search endpoint ──────────────────────────────────────────────────────────
+
+interface SearchQuery {
+  query: string;
+  limit?: number;
+  offset?: number;
+}
+
+interface Post {
+  id: number;
+  author: string;
+  content: string;
+  tip_total: string;
+  timestamp: number;
+}
+
+interface SearchResponse {
+  posts: Post[];
+  total: number;
+  has_more: boolean;
+}
+
+interface ErrorResponse {
+  error: string;
+  code: string;
+}
+
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 20;
+const DEFAULT_OFFSET = 0;
+
+app.post(
+  "/api/search/posts",
+  (req: Request, res: Response<SearchResponse | ErrorResponse>): void => {
+    const body = req.body as Partial<SearchQuery>;
+
+    if (
+      body.query === undefined ||
+      body.query === null ||
+      typeof body.query !== "string" ||
+      body.query.trim() === ""
+    ) {
+      res.status(400).json({ error: "query is required", code: "INVALID_QUERY" });
+      return;
+    }
+
+    const limit =
+      body.limit !== undefined ? Number(body.limit) : DEFAULT_LIMIT;
+    const offset =
+      body.offset !== undefined ? Number(body.offset) : DEFAULT_OFFSET;
+
+    if (!Number.isInteger(limit) || limit < 1) {
+      res
+        .status(400)
+        .json({ error: "limit must be a positive integer", code: "INVALID_QUERY" });
+      return;
+    }
+
+    if (limit > MAX_LIMIT) {
+      res.status(400).json({
+        error: `limit cannot exceed ${MAX_LIMIT}`,
+        code: "LIMIT_EXCEEDED",
+      });
+      return;
+    }
+
+    if (!Number.isInteger(offset) || offset < 0) {
+      res
+        .status(400)
+        .json({ error: "offset must be a non-negative integer", code: "INVALID_QUERY" });
+      return;
+    }
+
+    // TODO: integrate with the search database.
+    // Stub response — replace with real query logic.
+    res.json({ posts: [], total: 0, has_more: false });
+  }
+);
+
+// ── Error handler ─────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: Error, req: Request, res: Response, _next: NextFunction): void => {
+  console.error(err);
+  res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
+});
+
+export { app, apiLimiter };
+
+// ── Server bootstrap (skipped when imported in tests) ────────────────────────
+
+if (require.main === module) {
+  const PORT = parseInt(process.env.PORT ?? "3001", 10);
+  app.listen(PORT, () => {
+    console.log(`Indexer API listening on port ${PORT}`);
+    console.log(
+      `Rate limit: ${RATE_LIMIT_MAX} requests per ${RATE_LIMIT_WINDOW_MS / 1000}s per IP`
+    );
+  });
+}


### PR DESCRIPTION
Fixes #361
Fixes #363
Fixes #365
Fixes #355

## What changed

- **#361 — Governance doc**: Added `docs/GOVERNANCE.md` defining project roles (Contributor / Reviewer / Maintainer), decision-making for everyday vs. significant vs. breaking changes, the path to becoming a maintainer, CoC reference, and communication channels including the community Telegram link. Linked from `CONTRIBUTING.md` § Governance.

- **#363 — Contract security review**: Added `docs/security/CONTRACT_REVIEW.md` with a structured review of `LinkoraContract` (`packages/contracts/contracts/linkora-contracts/src/lib.rs`). Findings: 0 Critical, **1 High** (integer overflow in tip fee calculation), **3 Medium** (unbounded follower/following `Vec` growth, `get_followers` allows `limit=0` inconsistent with `get_following`, duplicate signer bypass in `pool_withdraw`), 3 Low, 3 Informational.

- **#365 — Indexer rate limiting**: Created `services/indexer/src/api/index.ts` (Express + `express-rate-limit`) with 100 req/min/IP default, returning `429 Too Many Requests` with a `Retry-After` header on breach. Both the window and max are env-configurable via `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX`. Updated `docs/indexer/API.md` with a Rate Limiting section documenting defaults, the 429 response shape, `RateLimit-*` headers, and env override examples.

- **#355 — SDK TypeDoc + GitHub Pages**: Added `pnpm docs` script (TypeDoc) to `packages/sdk/package.json`. Expanded `packages/sdk/README.md` with a Quick Start section covering client instantiation, calling functions, and simulation. Added `.github/workflows/sdk-docs.yml` to build and deploy TypeDoc output to GitHub Pages on every push to `main` that touches the SDK.

## Why

- Governance clarity is essential for contributor confidence and maintainer continuity.
- The security review surfaces a High-severity overflow and two Medium-severity pool and social-graph issues before they reach production.
- Rate limiting protects the indexer API from abuse and prevents a single client from exhausting search capacity.
- TypeDoc and GitHub Pages make the generated SDK client self-documenting and discoverable without needing the Stellar CLI installed.

## How to test

- **Governance**: Read `docs/GOVERNANCE.md` — verify all sections are present, Telegram link is correct, and `CONTRIBUTING.md` links to it.
- **Security review**: Read `docs/security/CONTRACT_REVIEW.md` — verify findings reference correct line numbers and code snippets in `lib.rs`.
- **Rate limiting**: `cd services/indexer && npm install && npx ts-node src/api/index.ts` then `for i in $(seq 1 101); do curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3001/api/search/posts -H "Content-Type: application/json" -d '{"query":"test"}'; done` — the 101st request should return `429`.
- **SDK docs**: `pnpm --filter sdk docs` — verify `packages/sdk/docs/index.html` is generated without errors.