### PR TITLE
chore(github): add label definitions and make labels sync target

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,107 @@
+# GitHub issue & PR label definitions for Linkora-socials.
+#
+# Synced to the repository with `make labels` (uses github-label-sync).
+# Any label that exists on GitHub but is NOT listed here will be removed,
+# so this file is the single source of truth for our labels.
+#
+# Color scheme (one hue per category, hex without the leading '#'):
+#   Platform            -> 1d76db (blue)    where the work runs
+#   Engineering domain  -> 5319e7 (purple)  which codebase/layer is affected
+#   Quality & process   -> d93f0b (red)     cross-cutting quality concerns
+#   Product feature      -> 0e8a16 (green)   user-facing feature areas
+#   Experience          -> d4c5f9 (lilac)   look, feel and inclusivity
+#   Triage & meta       -> assorted GitHub-standard colors for workflow labels
+
+# --- Platform (blue) -------------------------------------------------------
+- name: mobile
+  color: 1d76db
+  description: Mobile application work
+
+- name: web
+  color: 1d76db
+  description: Web application work
+
+- name: mini-apps
+  color: 1d76db
+  description: Mini-apps platform work
+
+# --- Engineering domain (purple) ------------------------------------------
+- name: contracts
+  color: 5319e7
+  description: Smart contract package and tooling
+
+- name: smart-contract
+  color: 5319e7
+  description: On-chain smart contract logic
+
+- name: sdk
+  color: 5319e7
+  description: SDK package and client libraries
+
+- name: indexer
+  color: 5319e7
+  description: Indexer and data ingestion
+
+# --- Quality & process (red) ----------------------------------------------
+- name: testing
+  color: d93f0b
+  description: Tests, test infrastructure and coverage
+
+- name: documentation
+  color: d93f0b
+  description: Documentation additions and improvements
+
+- name: security
+  color: d93f0b
+  description: Security-related issues and hardening
+
+# --- Product feature areas (green) ----------------------------------------
+- name: wallet
+  color: 0e8a16
+  description: Wallet feature area
+
+- name: feed
+  color: 0e8a16
+  description: Feed feature area
+
+- name: profile
+  color: 0e8a16
+  description: Profile feature area
+
+- name: pools
+  color: 0e8a16
+  description: Pools feature area
+
+- name: explore
+  color: 0e8a16
+  description: Explore feature area
+
+# --- Experience (lilac) ---------------------------------------------------
+- name: UX
+  color: d4c5f9
+  description: User experience and design
+
+- name: accessibility
+  color: d4c5f9
+  description: Accessibility (a11y) improvements
+
+# --- Triage & meta --------------------------------------------------------
+- name: developer experience
+  color: c5def5
+  description: Tooling and workflow for contributors
+
+- name: good first issue
+  color: 7057ff
+  description: Good for newcomers
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: bug
+  color: d73a4a
+  description: Something isn't working

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,34 @@ The `.github/CODEOWNERS` file maps directories to their maintainers:
 
 3. For urgent reviews or specific questions, you can also comment on the PR with a mention.
 
+## Issue Labels
+
+Issue and pull request labels are defined as code in [`.github/labels.yml`](.github/labels.yml) so they stay consistent across the repository. That file is the single source of truth: a label that exists on GitHub but is not listed there will be removed on the next sync.
+
+### Color Scheme
+
+Labels are grouped by category, and every label in a category shares a hue:
+
+| Category           | Color           | Meaning                                   |
+| ------------------ | --------------- | ----------------------------------------- |
+| Platform           | blue (`1d76db`) | Where the work runs (`mobile`, `web`, `mini-apps`) |
+| Engineering domain | purple (`5319e7`) | Which codebase/layer (`contracts`, `smart-contract`, `sdk`, `indexer`) |
+| Quality & process  | red (`d93f0b`)  | Cross-cutting quality (`testing`, `documentation`, `security`) |
+| Product feature     | green (`0e8a16`) | User-facing areas (`wallet`, `feed`, `profile`, `pools`, `explore`) |
+| Experience         | lilac (`d4c5f9`) | Look, feel and inclusivity (`UX`, `accessibility`) |
+| Triage & meta      | assorted        | Workflow labels (`developer experience`, `good first issue`, `help wanted`, `enhancement`, `bug`) |
+
+### Syncing Labels
+
+Maintainers can apply the definitions to GitHub with:
+
+```bash
+export GITHUB_TOKEN=<a token with repo scope>
+make labels
+```
+
+`make labels` runs [`github-label-sync`](https://github.com/Financial-Times/github-label-sync) against the `origin` remote using the `GITHUB_TOKEN` environment variable. To add, rename, recolor, or remove a label, edit `.github/labels.yml` and re-run the target.
+
 ## Security
 
 If you discover a security vulnerability, please review our [Security Policy](SECURITY.md) for responsible disclosure guidelines. Do not open public issues for security concerns.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build lint test format
+.PHONY: dev build lint test format labels
 
 dev:
 	@pnpm dev
@@ -14,3 +14,11 @@ test:
 
 format:
 	@pnpm format
+
+# Sync GitHub issue/PR labels from .github/labels.yml to the repository.
+# Requires the GITHUB_TOKEN env var (a token with repo scope). The target
+# repository is derived from the `origin` git remote.
+labels:
+	@test -n "$(GITHUB_TOKEN)" || { echo "GITHUB_TOKEN is not set"; exit 1; }
+	@repo=$$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$$##'); \
+		npx github-label-sync --access-token "$(GITHUB_TOKEN)" --labels .github/labels.yml "$$repo"


### PR DESCRIPTION
Closes #371

## Summary

Adds a Makefile target and a label definition file to keep GitHub issue/PR labels consistent across the repository.

## Changes

- **`.github/labels.yml`** (new) — single source of truth for all labels, with a documented, category-based color scheme:
  - Platform → blue (`1d76db`): `mobile`, `web`, `mini-apps`
  - Engineering domain → purple (`5319e7`): `contracts`, `smart-contract`, `sdk`, `indexer`
  - Quality & process → red (`d93f0b`): `testing`, `documentation`, `security`
  - Product feature → green (`0e8a16`): `wallet`, `feed`, `profile`, `pools`, `explore`
  - Experience → lilac (`d4c5f9`): `UX`, `accessibility`
  - Triage & meta → GitHub-standard colors: `developer experience`, `good first issue`, `help wanted`, `enhancement`, `bug`
- **`Makefile`** — adds a `labels` target that syncs labels via `github-label-sync` using the `GITHUB_TOKEN` env var. It fails fast if the token is unset and derives the target repo from the `origin` remote.
- **`CONTRIBUTING.md`** — documents the color scheme and how to run `make labels`.

## Acceptance criteria

- [x] `make labels` syncs labels to the repository using the `GITHUB_TOKEN` env var
- [x] Label colors follow a consistent scheme, documented in `.github/labels.yml`
- [x] Documented in `CONTRIBUTING.md`

## Usage

```bash
export GITHUB_TOKEN=<a token with repo scope>
make labels
```