### PR TITLE
fix(contracts): resolve issues #320 and #321

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/EVENTS.md
+++ b/packages/contracts/contracts/linkora-contracts/EVENTS.md
@@ -138,6 +138,26 @@ Emitted when tokens are withdrawn from a community pool.
   - `pool_id`: `Symbol`
   - `amount`: `i128`
 
+### FeeUpdated
+Emitted when protocol fee basis points are updated by the admin.
+
+- **Topic 0**: `Linkora`
+- **Topic 1**: `fee_upd`
+- **Topic 2**: `v1`
+- **Data Payload**: `FeeUpdatedEvent`
+  - `old_fee_bps`: `u32`
+  - `new_fee_bps`: `u32`
+
+### TreasuryUpdated
+Emitted when protocol treasury address is updated by the admin.
+
+- **Topic 0**: `Linkora`
+- **Topic 1**: `treasury`
+- **Topic 2**: `v1`
+- **Data Payload**: `TreasuryUpdatedEvent`
+  - `old_treasury`: `Address`
+  - `new_treasury`: `Address`
+
 ## Querying and Decoding
 
 ### Using Stellar CLI

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -980,7 +980,13 @@ impl LinkoraContract {
     pub fn set_fee(env: Env, fee_bps: u32) {
         Self::require_admin(&env);
         assert!(fee_bps <= 10_000, "invalid fee");
+        let old_fee_bps = Self::get_fee_bps(env.clone());
         env.storage().instance().set(&FEE_BPS, &fee_bps);
+        FeeUpdatedEvent {
+            old_fee_bps,
+            new_fee_bps: fee_bps,
+        }
+        .publish(&env);
     }
 
     pub fn set_treasury(env: Env, treasury: Address) {

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -383,6 +383,22 @@ impl LinkoraContract {
         ProfileSetEvent { user, username }.publish(&env);
     }
 
+    pub fn delete_profile(env: Env, user: Address) {
+        user.require_auth();
+        let key = StorageKey::Profile(user.clone());
+        let existing_profile: Profile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("profile does not exist");
+
+        env.storage().persistent().remove(&key);
+        env.storage()
+            .persistent()
+            .remove(&username_lookup_key(&existing_profile.username));
+        Self::decrement_profile_count(&env);
+    }
+
     pub fn get_profile(env: Env, user: Address) -> Option<Profile> {
         let key = StorageKey::Profile(user);
         let result: Option<Profile> = env.storage().persistent().get(&key);
@@ -1041,6 +1057,13 @@ impl LinkoraContract {
             .get(&ADMIN)
             .expect("not initialized");
         admin.require_auth();
+    }
+
+    fn decrement_profile_count(env: &Env) {
+        let count: u64 = env.storage().instance().get(&PROFILE_CT).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&PROFILE_CT, &count.saturating_sub(1));
     }
 
     /// Extend the TTL of a persistent entry after every write and on every

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -364,8 +364,7 @@ impl LinkoraContract {
         }
 
         if !env.storage().persistent().has(&key) {
-            let count: u64 = env.storage().instance().get(&PROFILE_CT).unwrap_or(0);
-            env.storage().instance().set(&PROFILE_CT, &(count + 1));
+            Self::increment_profile_count(&env);
         }
 
         // Write profile.
@@ -1064,6 +1063,11 @@ impl LinkoraContract {
         env.storage()
             .instance()
             .set(&PROFILE_CT, &count.saturating_sub(1));
+    }
+
+    fn increment_profile_count(env: &Env) {
+        let count: u64 = env.storage().instance().get(&PROFILE_CT).unwrap_or(0);
+        env.storage().instance().set(&PROFILE_CT, &(count + 1));
     }
 
     /// Extend the TTL of a persistent entry after every write and on every

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -991,7 +991,13 @@ impl LinkoraContract {
 
     pub fn set_treasury(env: Env, treasury: Address) {
         Self::require_admin(&env);
+        let old_treasury = Self::get_treasury(env.clone()).expect("treasury not set");
         env.storage().instance().set(&TREASURY, &treasury);
+        TreasuryUpdatedEvent {
+            old_treasury,
+            new_treasury: treasury,
+        }
+        .publish(&env);
     }
 
     pub fn get_fee_bps(env: Env) -> u32 {

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -242,6 +242,20 @@ pub struct ProposalExecutedEvent {
     pub recipient: Address,
 }
 
+#[contractevent]
+#[derive(Clone)]
+pub struct FeeUpdatedEvent {
+    pub old_fee_bps: u32,
+    pub new_fee_bps: u32,
+}
+
+#[contractevent]
+#[derive(Clone)]
+pub struct TreasuryUpdatedEvent {
+    pub old_treasury: Address,
+    pub new_treasury: Address,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -1004,6 +1004,36 @@ fn test_set_fee_zero_valid() {
 }
 
 #[test]
+fn test_set_fee_emits_fee_updated_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup_contract(&env);
+
+    let before_events = env.events().all().events().len();
+    client.set_fee(&150);
+    let after_events = env.events().all().events().len();
+
+    assert!(after_events > before_events, "set_fee should emit an event");
+}
+
+#[test]
+fn test_set_treasury_emits_treasury_updated_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup_contract(&env);
+
+    let new_treasury = Address::generate(&env);
+    let before_events = env.events().all().events().len();
+    client.set_treasury(&new_treasury);
+    let after_events = env.events().all().events().len();
+
+    assert!(
+        after_events > before_events,
+        "set_treasury should emit an event"
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_set_fee_non_admin_panics() {
     let env = Env::default();

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -476,6 +476,23 @@ fn test_profile_count() {
 }
 
 #[test]
+fn test_delete_profile_decrements_profile_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let user = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.set_profile(&user, &String::from_str(&env, "alice"), &token);
+    assert_eq!(client.get_profile_count(), 1);
+
+    client.delete_profile(&user);
+    assert_eq!(client.get_profile_count(), 0);
+    assert!(client.get_profile(&user).is_none());
+}
+
+#[test]
 fn test_post_count() {
     let env = Env::default();
     env.mock_all_auths();

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -493,6 +493,21 @@ fn test_delete_profile_decrements_profile_count() {
 }
 
 #[test]
+fn test_delete_nonexistent_profile_keeps_count_at_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let missing_user = Address::generate(&env);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.delete_profile(&missing_user);
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(client.get_profile_count(), 0);
+}
+
+#[test]
 fn test_post_count() {
     let env = Env::default();
     env.mock_all_auths();

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -508,6 +508,23 @@ fn test_delete_nonexistent_profile_keeps_count_at_zero() {
 }
 
 #[test]
+fn test_profile_replace_then_delete_updates_count_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let user = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.set_profile(&user, &String::from_str(&env, "alice"), &token);
+    client.set_profile(&user, &String::from_str(&env, "alice_updated"), &token);
+    assert_eq!(client.get_profile_count(), 1);
+
+    client.delete_profile(&user);
+    assert_eq!(client.get_profile_count(), 0);
+}
+
+#[test]
 fn test_post_count() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
- Emit `FeeUpdatedEvent` and `TreasuryUpdatedEvent` from admin update functions and document both event payloads in `EVENTS.md`.
- Add profile deletion support and safe profile-count decrement logic to keep `get_profile_count()` accurate without underflow.
- Add/extend contract tests covering fee/treasury event emission and profile count behavior for create, replace, delete, and missing-profile delete attempts.

## Verification
- Tests not run (intentionally skipped per instruction).

Closes #320
Closes #321
