### PR TITLE
Add GitHub Actions workflow for mobile build check

### DIFF
--- a/.github/workflows/mobile-check.yml
+++ b/.github/workflows/mobile-check.yml
@@ -1,0 +1,37 @@
+name: Mobile Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mobile/**'
+
+jobs:
+  mobile-check:
+    name: Type Check & Tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: TypeScript type check
+        run: pnpm exec tsc --noEmit
+
+      - name: Jest test suite
+        run: pnpm test


### PR DESCRIPTION
## Summary

Closes #337

### Changes
- `.github/workflows/mobile-check.yml` — new CI workflow for the mobile app

### What it does
- Triggers on PRs that touch `apps/mobile/**`
- Uses Node.js 24 and pnpm 9.15.9 (from `packageManager` field)
- Runs TypeScript type check (`tsc --noEmit`)
- Runs Jest test suite (`pnpm test`)

### Note on `expo export`
`expo` is not yet listed in `apps/mobile/package.json`, so the export
step was omitted. It should be added once Expo is introduced as a
dependency.