### PR TITLE
feat: implement deep link parsing and validation functions with tests

### DIFF
--- a/apps/mobile/__tests__/deepLinks.test.js
+++ b/apps/mobile/__tests__/deepLinks.test.js
@@ -1,0 +1,47 @@
+const { isValidDeepLink, parseDeepLink } = require('../utils/deepLinks')
+
+const stellarAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+describe('deep link parsing', () => {
+    it('parses post links', () => {
+        expect(parseDeepLink('linkora://post/123')).toEqual({
+            type: 'post',
+            path: '/post/123'
+        })
+    })
+
+    it('parses profile links', () => {
+        expect(parseDeepLink(`linkora://profile/${stellarAddress}`)).toEqual({
+            type: 'profile',
+            path: `/profile/${stellarAddress}`
+        })
+    })
+
+    it('parses pool links', () => {
+        expect(parseDeepLink('linkora://pool/main_pool-1')).toEqual({
+            type: 'pool',
+            path: '/pool/main_pool-1'
+        })
+    })
+
+    it('supports triple-slash deep links', () => {
+        expect(parseDeepLink('linkora:///post/abc_123')).toEqual({
+            type: 'post',
+            path: '/post/abc_123'
+        })
+    })
+
+    it('rejects invalid or malformed links', () => {
+        expect(parseDeepLink('https://linkora/post/123')).toBeNull()
+        expect(parseDeepLink('linkora://post')).toBeNull()
+        expect(parseDeepLink('linkora://post/123/extra')).toBeNull()
+        expect(parseDeepLink('linkora://profile/not-a-stellar-address')).toBeNull()
+        expect(parseDeepLink('linkora://pool/../../settings')).toBeNull()
+        expect(parseDeepLink('not a url')).toBeNull()
+    })
+
+    it('exposes a boolean validator', () => {
+        expect(isValidDeepLink('linkora://post/123')).toBe(true)
+        expect(isValidDeepLink('linkora://post/')).toBe(false)
+    })
+})

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,50 @@
+import { Stack, useRouter } from 'expo-router'
+import { useEffect } from 'react'
+import { Linking } from 'react-native'
+
+import { parseDeepLink } from '../utils/deepLinks'
+
+export default function RootLayout() {
+    const router = useRouter()
+
+    useEffect(() => {
+        let isMounted = true
+
+        async function handleInitialUrl() {
+            let initialUrl: string | null = null
+
+            try {
+                initialUrl = await Linking.getInitialURL()
+            } catch {
+                return
+            }
+
+            if (isMounted && initialUrl) {
+                handleDeepLink(initialUrl)
+            }
+        }
+
+        function handleDeepLink(url: string) {
+            const deepLink = parseDeepLink(url)
+
+            if (!deepLink) {
+                return
+            }
+
+            router.push(deepLink.path)
+        }
+
+        const subscription = Linking.addEventListener('url', ({ url }) => {
+            handleDeepLink(url)
+        })
+
+        handleInitialUrl()
+
+        return () => {
+            isMounted = false
+            subscription.remove()
+        }
+    }, [router])
+
+    return <Stack />
+}

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node'
+}

--- a/apps/mobile/utils/deepLinks.ts
+++ b/apps/mobile/utils/deepLinks.ts
@@ -1,0 +1,81 @@
+export type DeepLinkRoute =
+    | {
+          type: 'post'
+          path: `/post/${string}`
+      }
+    | {
+          type: 'profile'
+          path: `/profile/${string}`
+      }
+    | {
+          type: 'pool'
+          path: `/pool/${string}`
+      }
+
+const LINKORA_SCHEME = 'linkora:'
+const LINKORA_PREFIX = 'linkora://'
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/
+
+function safeDecode(value: string): string | null {
+    try {
+        return decodeURIComponent(value)
+    } catch {
+        return null
+    }
+}
+
+function getDeepLinkSegments(value: string): Array<string | null> | null {
+    if (!value.startsWith(LINKORA_PREFIX)) {
+        return null
+    }
+
+    const withoutScheme = value.slice(LINKORA_PREFIX.length)
+    const pathEndIndex = withoutScheme.search(/[?#]/)
+    const rawPath = pathEndIndex === -1 ? withoutScheme : withoutScheme.slice(0, pathEndIndex)
+    const path = rawPath.startsWith('/') ? rawPath.slice(1) : rawPath
+    const segments = path.split('/')
+
+    if (segments.length !== 2) {
+        return null
+    }
+
+    return segments.map(safeDecode)
+}
+
+function isValidId(value: string): boolean {
+    return ID_PATTERN.test(value)
+}
+
+function isValidProfileAddress(value: string): boolean {
+    return STELLAR_PUBLIC_KEY_PATTERN.test(value)
+}
+
+export function parseDeepLink(value: string): DeepLinkRoute | null {
+    if (!value.startsWith(LINKORA_SCHEME)) {
+        return null
+    }
+
+    const segments = getDeepLinkSegments(value)
+
+    if (!segments || segments.some((segment) => !segment)) {
+        return null
+    }
+
+    const [resource, rawId] = segments as [string, string]
+
+    switch (resource) {
+        case 'post':
+            return isValidId(rawId) ? { type: 'post', path: `/post/${rawId}` } : null
+        case 'profile':
+            return isValidProfileAddress(rawId) ? { type: 'profile', path: `/profile/${rawId}` } : null
+        case 'pool':
+            return isValidId(rawId) ? { type: 'pool', path: `/pool/${rawId}` } : null
+        default:
+            return null
+    }
+}
+
+export function isValidDeepLink(value: string): boolean {
+    return parseDeepLink(value) !== null
+}


### PR DESCRIPTION


closes #367 


Changes made:
- Added `apps/mobile/utils/deepLinks.ts`
  - Parses and validates supported deep links.
  - Supports:
    - `linkora://post/:id` -> `/post/:id`
    - `linkora://profile/:address` -> `/profile/:address`
    - `linkora://pool/:id` -> `/pool/:id`
  - Rejects malformed links, unsupported schemes, invalid IDs, invalid Stellar addresses, extra path segments, and traversal-like paths.

- Added `apps/mobile/app/_layout.tsx`
  - Registers a React Native `Linking` listener.
  - Handles both cold-start links via `Linking.getInitialURL()` and runtime links via `Linking.addEventListener`.
  - Navigates only when `parseDeepLink()` returns a valid route.
  - Invalid links are ignored gracefully without crashing.

- Added `apps/mobile/__tests__/deepLinks.test.js`
  - Covers valid post/profile/pool deep links.
  - Covers malformed and invalid links.
  - Verifies the boolean validator.

- Added `apps/mobile/jest.config.js`
  - Enables Jest to run the TypeScript deep link utility tests with `ts-jest`.

Note: I attempted to run tests, but local dependencies are not installed in this checkout, so `jest` was unavailable and `pnpm` was not installed.