### PR TITLE
Emit admin config update events

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/EVENTS.md
+++ b/packages/contracts/contracts/linkora-contracts/EVENTS.md
@@ -184,6 +184,28 @@ Emitted when a pool's signature threshold is updated.
   - `old_threshold`: `u32`
   - `new_threshold`: `u32`
 
+### FeeUpdated
+
+Emitted when the admin updates the protocol fee.
+
+- **Topic 0**: `Linkora`
+- **Topic 1**: `fee_updated_event`
+- **Topic 2**: `v1`
+- **Data Payload**: `FeeUpdatedEvent`
+  - `old_fee_bps`: `u32`
+  - `new_fee_bps`: `u32`
+
+### TreasuryUpdated
+
+Emitted when the admin updates the protocol treasury address.
+
+- **Topic 0**: `Linkora`
+- **Topic 1**: `treasury_updated_event`
+- **Topic 2**: `v1`
+- **Data Payload**: `TreasuryUpdatedEvent`
+  - `old_treasury`: `Address`
+  - `new_treasury`: `Address`
+
 ## Querying and Decoding
 
 ### Using Stellar CLI

--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -267,6 +267,20 @@ pub struct PoolThresholdUpdatedEvent {
     pub new_threshold: u32,
 }
 
+#[contractevent]
+#[derive(Clone)]
+pub struct FeeUpdatedEvent {
+    pub old_fee_bps: u32,
+    pub new_fee_bps: u32,
+}
+
+#[contractevent]
+#[derive(Clone)]
+pub struct TreasuryUpdatedEvent {
+    pub old_treasury: Address,
+    pub new_treasury: Address,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -1011,12 +1025,24 @@ impl LinkoraContract {
     pub fn set_fee(env: Env, fee_bps: u32) {
         Self::require_admin(&env);
         assert!(fee_bps <= 10_000, "invalid fee");
+        let old_fee_bps = Self::get_fee_bps(env.clone());
         env.storage().instance().set(&FEE_BPS, &fee_bps);
+        FeeUpdatedEvent {
+            old_fee_bps,
+            new_fee_bps: fee_bps,
+        }
+        .publish(&env);
     }
 
     pub fn set_treasury(env: Env, treasury: Address) {
         Self::require_admin(&env);
+        let old_treasury = Self::get_treasury(env.clone()).expect("treasury not set");
         env.storage().instance().set(&TREASURY, &treasury);
+        TreasuryUpdatedEvent {
+            old_treasury,
+            new_treasury: treasury,
+        }
+        .publish(&env);
     }
 
     pub fn get_fee_bps(env: Env) -> u32 {

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -1004,6 +1004,44 @@ fn test_set_fee_zero_valid() {
 }
 
 #[test]
+fn test_set_fee_emits_fee_updated_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup_contract(&env);
+
+    let event_count_before = env.events().all().events().len();
+
+    client.set_fee(&250);
+
+    assert_eq!(client.get_fee_bps(), 250);
+    assert_eq!(
+        env.events().all().events().len(),
+        event_count_before + 1,
+        "FeeUpdatedEvent should be emitted"
+    );
+}
+
+#[test]
+fn test_set_treasury_emits_treasury_updated_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, old_treasury) = setup_contract(&env);
+    let new_treasury = Address::generate(&env);
+
+    let event_count_before = env.events().all().events().len();
+
+    client.set_treasury(&new_treasury);
+
+    assert_eq!(client.get_treasury(), Some(new_treasury));
+    assert_eq!(
+        env.events().all().events().len(),
+        event_count_before + 1,
+        "TreasuryUpdatedEvent should be emitted"
+    );
+    assert_ne!(client.get_treasury(), Some(old_treasury));
+}
+
+#[test]
 #[should_panic]
 fn test_set_fee_non_admin_panics() {
     let env = Env::default();


### PR DESCRIPTION
Closes #320
## Summary
- Added `FeeUpdatedEvent { old_fee_bps, new_fee_bps }` emission in `set_fee`
- Added `TreasuryUpdatedEvent { old_treasury, new_treasury }` emission in `set_treasury`
- Documented both events in `EVENTS.md`
- Added tests verifying event emission for fee and treasury updates

## Testing
- `git diff --check`
- Not run: `cargo fmt` / `cargo test` because `cargo` is unavailable in this environment