### PR TITLE
[Web] Implement Freighter wallet connect and global wallet context

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { WalletProvider } from "@/components/WalletProvider";
+import { NavBar } from "@/components/NavBar";
 
 export const metadata: Metadata = {
   title: "Linkora",
@@ -9,7 +11,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <WalletProvider>
+          <NavBar />
+          <main>{children}</main>
+        </WalletProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useWallet } from "@/hooks/useWallet";
+
+/** Truncates a Stellar address to G…XXXX format */
+function truncateAddress(address: string): string {
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+export function NavBar() {
+  const { address, connected, network, connect, disconnect } = useWallet();
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-[var(--border)] bg-[var(--background)]/80 backdrop-blur-sm">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+        {/* Brand */}
+        <a
+          href="/"
+          className="text-xl font-extrabold tracking-tight text-violet-500 hover:text-violet-400 transition-colors"
+        >
+          Linkora
+        </a>
+
+        {/* Right side */}
+        <div className="flex items-center gap-3">
+          {connected && address ? (
+            <>
+              {/* Network badge */}
+              {network && (
+                <span className="hidden sm:inline-flex items-center rounded-full bg-violet-900/40 px-2.5 py-0.5 text-xs font-medium text-violet-300 border border-violet-700/50">
+                  {network}
+                </span>
+              )}
+
+              {/* Address chip */}
+              <span
+                className="font-mono text-sm text-[var(--foreground)] bg-[var(--muted)] border border-[var(--border)] rounded-lg px-3 py-1.5 select-all"
+                title={address}
+                aria-label={`Connected address: ${address}`}
+              >
+                {truncateAddress(address)}
+              </span>
+
+              {/* Disconnect */}
+              <button
+                onClick={disconnect}
+                className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm font-medium text-[var(--text-muted)] hover:border-red-500/60 hover:text-red-400 transition-colors"
+                aria-label="Disconnect wallet"
+              >
+                Disconnect
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={connect}
+              className="rounded-lg bg-violet-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-violet-500 transition-colors"
+              aria-label="Connect Freighter wallet"
+            >
+              Connect Wallet
+            </button>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/src/components/WalletProvider.tsx
+++ b/apps/web/src/components/WalletProvider.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const LS_KEY = "linkora_wallet_address";
+const LS_NETWORK_KEY = "linkora_wallet_network";
+
+export interface WalletContextValue {
+  address: string | null;
+  connected: boolean;
+  network: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+export const WalletContext = createContext<WalletContextValue>({
+  address: null,
+  connected: false,
+  network: null,
+  connect: async () => {},
+  disconnect: () => {},
+});
+
+export function useWalletContext(): WalletContextValue {
+  return useContext(WalletContext);
+}
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null);
+  const [network, setNetwork] = useState<string | null>(null);
+
+  // Rehydrate from localStorage on mount, then verify Freighter still agrees
+  useEffect(() => {
+    const savedAddress = localStorage.getItem(LS_KEY);
+    const savedNetwork = localStorage.getItem(LS_NETWORK_KEY);
+    if (savedAddress) {
+      setAddress(savedAddress);
+      setNetwork(savedNetwork);
+    }
+
+    // Silently verify the saved session is still valid
+    (async () => {
+      try {
+        const { isConnected, getPublicKey, getNetwork } = await import(
+          "@stellar/freighter-api"
+        );
+        const still = await isConnected();
+        if (!still) {
+          // Freighter was disconnected externally — clear persisted state
+          setAddress(null);
+          setNetwork(null);
+          localStorage.removeItem(LS_KEY);
+          localStorage.removeItem(LS_NETWORK_KEY);
+          return;
+        }
+        const [pub, net] = await Promise.all([getPublicKey(), getNetwork()]);
+        if (pub) {
+          setAddress(pub);
+          setNetwork(net ?? null);
+          localStorage.setItem(LS_KEY, pub);
+          if (net) localStorage.setItem(LS_NETWORK_KEY, net);
+        }
+      } catch {
+        // Freighter not installed — leave persisted state as-is so UI can
+        // show the "install" prompt rather than silently wiping the address.
+      }
+    })();
+  }, []);
+
+  const connect = useCallback(async () => {
+    try {
+      const { requestAccess, getPublicKey, getNetwork } = await import(
+        "@stellar/freighter-api"
+      );
+      await requestAccess();
+      const [pub, net] = await Promise.all([getPublicKey(), getNetwork()]);
+      if (pub) {
+        setAddress(pub);
+        setNetwork(net ?? null);
+        localStorage.setItem(LS_KEY, pub);
+        if (net) localStorage.setItem(LS_NETWORK_KEY, net ?? "");
+      }
+    } catch {
+      // User rejected the connection request — do nothing
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setNetwork(null);
+    localStorage.removeItem(LS_KEY);
+    localStorage.removeItem(LS_NETWORK_KEY);
+  }, []);
+
+  return (
+    <WalletContext.Provider
+      value={{
+        address,
+        connected: !!address,
+        network,
+        connect,
+        disconnect,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}

--- a/apps/web/src/components/onboarding/OnboardingFlow.tsx
+++ b/apps/web/src/components/onboarding/OnboardingFlow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useWallet } from "@/hooks/useWallet";
+import { useOnboardingWallet } from "@/hooks/useWallet";
 import { StepIndicator } from "./StepIndicator";
 import { NotInstalledState } from "./NotInstalledState";
 import { NotConnectedState } from "./NotConnectedState";
@@ -9,7 +9,7 @@ import { FundWalletState } from "./FundWalletState";
 import { NoProfileState } from "./NoProfileState";
 
 export function OnboardingFlow() {
-  const { state, wallet, connect, refresh } = useWallet();
+  const { state, wallet, connect, refresh } = useOnboardingWallet();
   const [skipFund, setSkipFund] = useState(false);
 
   const funded = wallet.balance !== null && parseFloat(wallet.balance) > 0;

--- a/apps/web/src/hooks/useWallet.ts
+++ b/apps/web/src/hooks/useWallet.ts
@@ -1,6 +1,16 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useWalletContext } from "@/components/WalletProvider";
+
+// Re-export the context hook as the canonical useWallet for simple consumers
+// (nav bar, header, etc.) that only need { address, connected, network,
+// connect, disconnect }.
+export { useWalletContext as useWallet } from "@/components/WalletProvider";
+
+// ---------------------------------------------------------------------------
+// Richer onboarding state — used by OnboardingFlow
+// ---------------------------------------------------------------------------
 
 export type WalletState =
   | "loading"
@@ -20,24 +30,26 @@ const HORIZON_TESTNET = "https://horizon-testnet.stellar.org";
 async function fetchXlmBalance(address: string): Promise<string> {
   try {
     const res = await fetch(`${HORIZON_TESTNET}/accounts/${address}`);
-    if (!res.ok) return "0"; // account not funded yet
+    if (!res.ok) return "0";
     const data = await res.json();
-    const native = (data.balances as { asset_type: string; balance: string }[]).find(
-      (b) => b.asset_type === "native"
-    );
+    const native = (
+      data.balances as { asset_type: string; balance: string }[]
+    ).find((b) => b.asset_type === "native");
     return native?.balance ?? "0";
   } catch {
     return "0";
   }
 }
 
-export function useWallet() {
+/**
+ * useOnboardingWallet — full onboarding state machine used by OnboardingFlow.
+ * Delegates connect/disconnect to WalletContext so state stays in sync.
+ */
+export function useOnboardingWallet() {
+  const { address, connected, network, connect: ctxConnect } = useWalletContext();
+
   const [state, setState] = useState<WalletState>("loading");
-  const [wallet, setWallet] = useState<WalletInfo>({
-    address: null,
-    network: null,
-    balance: null,
-  });
+  const [balance, setBalance] = useState<string | null>(null);
 
   const detectState = useCallback(async () => {
     const hasFreighter =
@@ -50,51 +62,37 @@ export function useWallet() {
     }
 
     try {
-      const { isConnected, getPublicKey, getNetwork } = await import("@stellar/freighter-api");
-      const connected = await isConnected();
+      const { isConnected } = await import("@stellar/freighter-api");
+      const isConn = await isConnected();
 
-      if (!connected) {
+      if (!isConn || !connected || !address) {
         setState("not_connected");
+        setBalance(null);
         return;
       }
 
-      const [address, networkResult] = await Promise.all([
-        getPublicKey(),
-        getNetwork(),
-      ]);
-
-      if (!address) {
-        setState("not_connected");
-        return;
-      }
-
-      const network = networkResult ?? null;
-      const balance = await fetchXlmBalance(address);
-
-      setWallet({ address, network: network ?? null, balance });
+      const bal = await fetchXlmBalance(address);
+      setBalance(bal);
 
       // TODO: replace with actual contract call to get_profile(address)
       setState("connected_no_profile");
     } catch {
       setState("not_connected");
     }
-  }, []);
+  }, [address, connected]);
 
   useEffect(() => {
     detectState();
   }, [detectState]);
 
   const connect = useCallback(async () => {
-    try {
-      const { requestAccess } = await import("@stellar/freighter-api");
-      await requestAccess();
-      await detectState();
-    } catch {
-      // user rejected
-    }
-  }, [detectState]);
+    await ctxConnect();
+    // detectState will re-run via the effect when `address` / `connected` change
+  }, [ctxConnect]);
 
   const markProfileCreated = useCallback(() => setState("ready"), []);
+
+  const wallet: WalletInfo = { address, network, balance };
 
   return { state, wallet, connect, markProfileCreated, refresh: detectState };
 }


### PR DESCRIPTION
Closes #293  [Web] Implement Freighter wallet connect and global wallet context
- Add WalletProvider with WalletContext exposing { address, connected, network, connect, disconnect }
- Persist connection across page refreshes via localStorage with silent Freighter re-validation on mount
- Add NavBar with connect/disconnect button and truncated address display
- Update useWallet.ts to re-export useWalletContext as useWallet and introduce useOnboardingWallet for the richer onboarding state machine
- Wrap RootLayout with WalletProvider and render NavBar
- Update OnboardingFlow to use useOnboardingWallet

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] Tests added or updated for changed behaviour
- [ ] Existing tests pass (`cargo test`)
- [ ] Changes are focused — one concern per PR
- [ ] If a contract function was added or changed, the README API table is updated
- [ ] No unresolved merge conflicts
