### PR TITLE
docs: update SECURITY.md with vulnerability disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,100 +2,70 @@
 
 ## Supported Versions
 
-This security policy applies to all versions of the Linkora-socials smart contracts. The current version is `0.1.0` as specified in `packages/contracts/contracts/linkora-contracts/Cargo.toml`.
+| Version | Supported |
+|---------|-----------|
+| 0.1.x (current) | ✅ Yes |
 
-## Scope
+Security fixes are applied to the latest version only. This project is in prototype stage and has not been audited for production use.
 
-This security policy applies to smart contract code in:
+## Reporting a Vulnerability
 
-- `packages/contracts/contracts/linkora-contracts/src/lib.rs` - Core contract implementation
-- `packages/contracts/contracts/linkora-contracts/src/test.rs` - Test suite (for test-related vulnerabilities)
+**Do not open a public GitHub issue for security vulnerabilities.**
 
-**In Scope:**
-- Smart contract access control vulnerabilities
-- Token transfer and tipping logic flaws
-- Pool manipulation attacks
-- Storage layout and TTL issues
-- Authorization bypasses
-- Economic/financial vulnerabilities
-- Integer overflow/underflow issues
+Use **[GitHub Security Advisories](https://github.com/Epta-Node/Linkora-social/security/advisories/new)** to report privately. This keeps the disclosure confidential until a fix is ready.
 
-**Out of Scope:**
-- Frontend mock data and UI components (not yet included in this repository)
-- Backend services and APIs (not yet included in this repository)
-- Issues requiring physical access to user devices
-- Social engineering attacks
-- Third-party dependencies (unless directly exploitable in contract context)
-- Network-level attacks on Stellar infrastructure
-
-The repository is currently a prototype. Frontend and backend services are not included here, and no production deployment guarantees are implied.
-
-## How to Report a Vulnerability
-
-If you discover a vulnerability, please do **not** open a public issue first.
-
-**Private Disclosure Channels:**
-
-1. **Preferred:** Open a private GitHub security advisory for this repository
-2. **Alternative:** Email: `security@linkora.social`
-
-**What to Include:**
-- A clear description of the issue and affected function(s)
-- Reproduction steps or proof of concept
-- Impact assessment (fund loss, denial of service, access control bypass, etc.)
-- Suggested remediation (optional but appreciated)
-- Your contact information for follow-up
+Include in your report:
+- Affected function(s) or file(s)
+- Steps to reproduce or proof of concept
+- Impact assessment (e.g. fund loss, access control bypass, DoS)
+- Suggested fix (optional)
 
 ## Response Timeline
 
-Our security response team commits to the following timelines:
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 48 hours |
+| Triage & severity classification | Within 7 days |
+| Fix for **Critical** vulnerabilities | Within 14 days |
+| Fix for **High** vulnerabilities | Within 30 days |
+| Fix for **Medium / Low** vulnerabilities | Next scheduled release |
 
-- **Initial Response:** Within 48 hours of receiving a valid report
-- **Triage Assessment:** Within 7 days - severity classification and impact analysis
-- **Remediation Timeline:**
-  - **Critical:** Fix deployed within 30 days
-  - **High:** Fix deployed within 60 days  
-  - **Medium:** Fix deployed within 90 days
-  - **Low:** Addressed in next scheduled release
+We will keep you informed throughout the process and coordinate disclosure timing with you before publishing a security advisory.
 
-**Priority Levels:**
-- **Critical:** Direct fund loss, pool drainage, unauthorized token transfers
-- **High:** Access control bypass, contract upgrade vulnerabilities
-- **Medium:** DOS attacks, logic errors that don't directly cause fund loss
-- **Low:** Information disclosure, minor logic issues
+## Severity Definitions
+
+- **Critical** — Direct loss of funds, pool drainage, unauthorized token transfers
+- **High** — Access control bypass, contract upgrade abuse
+- **Medium** — Denial of service, logic errors without direct fund loss
+- **Low** — Information disclosure, minor logic issues
+
+## Out-of-Scope Items
+
+The following are **not** eligible for security reports:
+
+- Frontend UI components and mock data (not yet in this repository)
+- Backend services and APIs (not yet in this repository)
+- Issues requiring physical access to a user's device
+- Social engineering attacks
+- Third-party dependencies unless directly exploitable in the contract context
+- Network-level attacks on Stellar infrastructure
+- Vulnerabilities in already-deprecated or unsupported versions
+
+## Bug Bounty
+
+There is no formal paid bug bounty program at this time. Researchers who responsibly disclose valid vulnerabilities will be:
+
+- Credited in the published security advisory (with permission)
+- Acknowledged in release notes and community channels
+
+This may be revisited as the project matures toward production.
 
 ## Disclosure Process
 
-1. **Report Submission:** Vulnerability reported via private channel
-2. **Acknowledgment:** Security team confirms receipt within 48 hours
-3. **Triage:** Team assesses severity and impact within 7 days
-4. **Remediation:** Fix developed and tested based on severity timeline
-5. **Coordination:** If multiple vendors are affected, we coordinate disclosure
-6. **Publication:** Security advisory published after fix is deployed
-7. **Credit:** Reporter credited in security advisory (with permission)
-
-## Security Guarantees
-
-This project is currently in **prototype stage** and has not completed a formal external audit. While we take security seriously and will address reported vulnerabilities promptly:
-
-- Do not use with high-value production funds
-- Additional security reviews are recommended before mainnet deployment
-- Known limitations are described in the root `README.md` under "Current Limitations"
-
-## Security Best Practices for Users
-
-- Use dedicated accounts for contract interactions
-- Start with small test transactions
-- Keep private keys secure
-- Monitor contract upgrades and announcements
-- Review the source code before significant interactions
-
-## Recognition Program
-
-While we don't currently offer a formal bug bounty program, we will:
-
-- Credit security researchers in our release notes (with permission)
-- Provide recognition in our community channels
-- Consider contributions for future bounty programs
-
-Thank you for helping keep Linkora-socials secure!
+1. Reporter submits via GitHub Security Advisories (private)
+2. Team acknowledges within 48 hours
+3. Team triages severity within 7 days
+4. Fix developed and reviewed based on severity timeline above
+5. Reporter notified before public disclosure
+6. Security advisory published after fix is deployed
+7. Reporter credited (with permission)


### PR DESCRIPTION
Closes #340

## Changes
- Rewrote `SECURITY.md` to meet the acceptance criteria in issue #340

## Sections added / updated
- **Supported versions** table
- **Reporting a vulnerability** — private disclosure via GitHub Security Advisories with a direct link
- **Response timeline** — acknowledgement within 48 h, critical fix within 14 days
- **Severity definitions**
- **Out-of-scope items**
- **Bug bounty scope**
- **Disclosure process** step-by-step

## Notes
- `README.md` already contains a link to `SECURITY.md` under the Security section — no change needed there.