### PR TITLE
ci: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a reproducible problem in Linkora Social
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS:
+        - Browser / client:
+        - Repository version / commit:
+        - Network (Testnet / Mainnet):
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/contract_issue.yml
+++ b/.github/ISSUE_TEMPLATE/contract_issue.yml
@@ -1,0 +1,49 @@
+name: Contract Issue
+description: Report a bug, logic error, or security concern in a Soroban contract function
+title: "[Contract]: "
+labels: [contract, bug]
+body:
+  - type: input
+    id: affected_function
+    attributes:
+      label: Affected Function
+      description: Name of the contract function(s) involved (e.g. `tip`, `pool_withdraw`)
+      placeholder: e.g. tip
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_case
+    attributes:
+      label: Test Case
+      description: Minimal Rust test or reproduction steps that demonstrate the issue.
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: security_impact
+    attributes:
+      label: Security Impact
+      description: |
+        Could this lead to fund loss, access control bypass, DoS, or other security impact?
+        If yes, consider reporting privately via GitHub Security Advisories instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - soroban-sdk version:
+        - stellar-cli version:
+        - Network (Testnet / Mainnet / local):

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Suggest a new capability or workflow improvement
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the change you want to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files, contracts, or components would be affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you evaluated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Contract change (logic, storage, or API)
+- [ ] Documentation update
+- [ ] Refactor / chore
+
+## Testing Done
+
+<!-- Describe what you tested and how. -->
+
+- [ ] `cargo test` passes
+- [ ] New tests added for changed behaviour
+- [ ] Manually verified on Testnet (if applicable)
+
+## Checklist
+
+- [ ] Changes are focused — one concern per PR
+- [ ] If a contract function was added or changed, the README API table is updated
+- [ ] No unresolved merge conflicts
+- [ ] No secrets or private keys committed
+
+## Related Issue
+
+Closes #


### PR DESCRIPTION
Closes #334

## Summary
Creates structured GitHub issue and PR templates for all contribution types.

## Files Added
- `.github/ISSUE_TEMPLATE/bug_report.yml` — description, steps to reproduce, expected vs actual, environment
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem statement, proposed solution, scope, alternatives
- `.github/ISSUE_TEMPLATE/contract_issue.yml` — affected function, test case, security impact, environment
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, type of change, testing done, checklist

## Type of Change
- [x] Documentation update

## Checklist
- [x] No existing tests affected
- [x] No merge conflicts