### PR TITLE
feat(indexer): add Docker Compose setup for indexer and PostgreSQL

### DIFF
--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -1,0 +1,15 @@
+NODE_ENV=development
+
+# PostgreSQL
+POSTGRES_USER=linkora
+POSTGRES_PASSWORD=linkora
+POSTGRES_DB=linkora
+DATABASE_URL=postgresql://linkora:linkora@postgres:5432/linkora
+
+# Stellar
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+START_LEDGER=0
+
+# Indexer API
+PORT=3000

--- a/services/indexer/Dockerfile
+++ b/services/indexer/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -70,13 +70,58 @@ CREATE TABLE likes (
 );
 ```
 
-## Setup
+## Local Setup (Docker)
+
+The fastest way to run the indexer and PostgreSQL together is Docker Compose.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
+
+### Steps
+
+```bash
+# 1. Copy and edit environment variables
+cp .env.example .env
+# Edit .env — set CONTRACT_ID, START_LEDGER, and STELLAR_RPC_URL at minimum
+
+# 2. Start both services (migrations run automatically on first boot)
+docker compose up --build
+```
+
+The indexer API will be available at `http://localhost:3000`.
+PostgreSQL is exposed on port `5432`.
+
+To stop and remove containers:
+
+```bash
+docker compose down
+```
+
+To also remove the database volume:
+
+```bash
+docker compose down -v
+```
+
+### Environment Variables
+
+See [`.env.example`](.env.example) for all required variables.
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `STELLAR_RPC_URL` | Soroban RPC endpoint |
+| `CONTRACT_ID` | Deployed Linkora contract address |
+| `START_LEDGER` | Ledger sequence to start indexing from |
+| `PORT` | API port (default: `3000`) |
+
+## Manual Setup
 
 ### Prerequisites
 
 - Node.js 18+
 - PostgreSQL 14+
-- Stellar RPC endpoint
 
 ### Installation
 
@@ -87,23 +132,18 @@ npm install
 ### Database Setup
 
 ```bash
-# Run migrations
-npm run migrate
-
-# Or manually
-psql -U postgres -d linkora -f migrations/002_posts.sql
-psql -U postgres -d linkora -f migrations/004_tips_likes.sql
+# Apply migrations manually
+psql "$DATABASE_URL" -f migrations/001_profiles.sql
+psql "$DATABASE_URL" -f migrations/002_posts.sql
+psql "$DATABASE_URL" -f migrations/004_tips_likes.sql
+psql "$DATABASE_URL" -f migrations/005_pools.sql
 ```
 
 ### Configuration
 
-Create `.env` file:
-
-```env
-DATABASE_URL=postgresql://user:password@localhost:5432/linkora
-STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-START_LEDGER=12345
+```bash
+cp .env.example .env
+# Edit .env with your values
 ```
 
 ## Running

--- a/services/indexer/docker-compose.yml
+++ b/services/indexer/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-linkora}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-linkora}
+      POSTGRES_DB: ${POSTGRES_DB:-linkora}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./migrations:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-linkora}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  indexer:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-linkora}:${POSTGRES_PASSWORD:-linkora}@postgres:5432/${POSTGRES_DB:-linkora}
+    ports:
+      - "${PORT:-3000}:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Closes #332

## Summary
Adds Docker Compose setup so `docker compose up` starts both the indexer service and PostgreSQL with migrations applied automatically.

## Files Added / Modified
- `services/indexer/docker-compose.yml` — indexer + `postgres:16-alpine`, healthcheck on postgres, migrations mounted via `/docker-entrypoint-initdb.d`
- `services/indexer/Dockerfile` — `node:18-alpine` production image
- `services/indexer/.env.example` — documents all required env vars (`DATABASE_URL`, `STELLAR_RPC_URL`, `CONTRACT_ID`, `START_LEDGER`, `PORT`)
- `services/indexer/README.md` — updated with Docker local setup instructions and env variable table

## How migrations run automatically
PostgreSQL's official image executes all `.sql` files mounted at `/docker-entrypoint-initdb.d` on first boot. The `migrations/` directory is mounted read-only to that path.

## Type of Change
- [x] New feature