### PR TITLE
feat(mini-apps): build mini app launcher tab in mobile navigation

### DIFF
--- a/apps/mobile/app/(tabs)/mini-apps.tsx
+++ b/apps/mobile/app/(tabs)/mini-apps.tsx
@@ -1,12 +1,84 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useState, useCallback } from "react";
+import { Alert, FlatList, StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+
+import { MiniAppIcon, MiniApp } from "../../components/MiniAppIcon";
+import { EmptyState } from "../../components/EmptyState";
+
+const INSTALLED_APPS: MiniApp[] = [
+  {
+    id: "tip-jar",
+    name: "Tip Jar",
+    description: "Tip any Linkora post with XLM using your connected wallet.",
+    icon: "",
+    entry: "https://linkora-social.github.io/mini-apps/tip-jar/index.html",
+    permissions: ["wallet.getAddress", "wallet.signTransaction"],
+  },
+  {
+    id: "poll-maker",
+    name: "Poll Maker",
+    description: "Create and vote on polls in your community.",
+    icon: "",
+    entry: "https://linkora-social.github.io/mini-apps/poll-maker/index.html",
+    permissions: ["wallet.getAddress"],
+  },
+];
 
 export default function MiniAppsScreen() {
+  const router = useRouter();
+  const [apps, setApps] = useState<MiniApp[]>(INSTALLED_APPS);
+
+  const handlePress = useCallback(
+    (app: MiniApp) => {
+      router.push(
+        `/mini-app/${app.id}?name=${encodeURIComponent(app.name)}&entry=${encodeURIComponent(app.entry)}` as Parameters<typeof router.push>[0],
+      );
+    },
+    [router],
+  );
+
+  const handleLongPress = useCallback(
+    (app: MiniApp) => {
+      Alert.alert(
+        `Uninstall ${app.name}?`,
+        "This will remove the mini app from your launcher.",
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Uninstall",
+            style: "destructive",
+            onPress: () => {
+              setApps((prev) => prev.filter((a) => a.id !== app.id));
+            },
+          },
+        ],
+      );
+    },
+    [],
+  );
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Mini Apps</Text>
-      <Text style={styles.subtitle}>Browse and launch mini apps</Text>
-    </View>
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={apps.length === 0 ? styles.emptyContainer : styles.listContent}
+      data={apps}
+      keyExtractor={(item) => item.id}
+      numColumns={3}
+      columnWrapperStyle={apps.length > 0 ? styles.row : undefined}
+      renderItem={({ item }) => (
+        <MiniAppIcon app={item} onPress={handlePress} onLongPress={handleLongPress} />
+      )}
+      ListEmptyComponent={
+        <EmptyState
+          title="No Mini Apps"
+          description="Discover and install mini apps to enhance your Linkora experience."
+          actionText="Browse Discovery"
+          onActionPress={() =>
+            router.push("/(tabs)/explore" as Parameters<typeof router.push>[0])
+          }
+        />
+      }
+    />
   );
 }
 
@@ -14,18 +86,16 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#0f172a",
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 24,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: "700",
-    color: "#f1f5f9",
-    marginBottom: 8,
+  listContent: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    paddingBottom: 32,
   },
-  subtitle: {
-    fontSize: 14,
-    color: "#94a3b8",
+  emptyContainer: {
+    flex: 1,
+  },
+  row: {
+    justifyContent: "flex-start",
   },
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -114,6 +114,10 @@ export default function RootLayout() {
         {/* Detail screens — hidden from tab bar */}
         <Tabs.Screen name="post/[id]" options={{ href: null, headerShown: true, title: "Post" }} />
         <Tabs.Screen
+          name="mini-app/[id]"
+          options={{ href: null, headerShown: true, title: "Mini App" }}
+        />
+        <Tabs.Screen
           name="profile/[address]"
           options={{ href: null, headerShown: true, title: "Profile" }}
         />

--- a/apps/mobile/app/mini-app/[id].tsx
+++ b/apps/mobile/app/mini-app/[id].tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+
+export default function MiniAppHostScreen() {
+  const { name } = useLocalSearchParams<{ id: string; name: string; entry: string }>();
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.placeholder}>
+        <Text style={styles.icon}>🧩</Text>
+        <Text style={styles.title}>{name ?? "Mini App"}</Text>
+        <Text style={styles.subtitle}>
+          Mini app host container will render here via WebView.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#f1f5f9",
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: "#94a3b8",
+    textAlign: "center",
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile/components/MiniAppIcon.tsx
+++ b/apps/mobile/components/MiniAppIcon.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+export interface MiniApp {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  entry: string;
+  permissions: string[];
+}
+
+interface MiniAppIconProps {
+  app: MiniApp;
+  onPress: (app: MiniApp) => void;
+  onLongPress?: (app: MiniApp) => void;
+}
+
+const FALLBACK_CHAR = "★";
+
+export function MiniAppIcon({ app, onPress, onLongPress }: MiniAppIconProps) {
+  const hasValidIcon = app.icon && (app.icon.startsWith("data:") || app.icon.startsWith("http"));
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={() => onPress(app)}
+      onLongPress={() => onLongPress?.(app)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${app.name}`}
+      delayLongPress={500}
+    >
+      <View style={styles.iconWrapper}>
+        {hasValidIcon ? (
+          <Image source={{ uri: app.icon }} style={styles.icon} />
+        ) : (
+          <Text style={styles.fallback}>{FALLBACK_CHAR}</Text>
+        )}
+      </View>
+      <Text style={styles.label} numberOfLines={1}>
+        {app.name}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "30%",
+    alignItems: "center",
+    marginVertical: 12,
+    marginHorizontal: "1.5%",
+  },
+  iconWrapper: {
+    width: 64,
+    height: 64,
+    borderRadius: 16,
+    backgroundColor: "#1e293b",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "#334155",
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+  },
+  fallback: {
+    fontSize: 28,
+    color: "#6366f1",
+  },
+  label: {
+    marginTop: 6,
+    fontSize: 12,
+    color: "#cbd5e1",
+    fontWeight: "600",
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/components/index.ts
+++ b/apps/mobile/components/index.ts
@@ -5,3 +5,5 @@ export { SearchBar } from "./SearchBar";
 export { ProfileRow } from "./ProfileRow";
 export { PoolRow } from "./PoolRow";
 export { WalletButton } from "./WalletButton";
+export { MiniAppIcon } from "./MiniAppIcon";
+export type { MiniApp } from "./MiniAppIcon";


### PR DESCRIPTION
## Summary

Implements the mini app launcher tab as specified in issue #289.

## Changes

### New files
- **`apps/mobile/components/MiniAppIcon.tsx`** - Grid tile component rendering app icon (with fallback star character) and name. Supports tap (open) and long-press (uninstall) handlers.
- **`apps/mobile/app/mini-app/[id].tsx`** - Mini app host container screen. Receives app name and entry URL via query params. Placeholder ready for WebView integration.

### Modified files
- **`apps/mobile/app/(tabs)/mini-apps.tsx`** - Replaced placeholder stub with full launcher: 3-column FlatList grid, long-press triggers Alert with uninstall option (removes from local state), empty state with link to Explore discovery tab.
- **`apps/mobile/app/_layout.tsx`** - Added `mini-app/[id]` as hidden stack screen (same pattern as `post/[id]`, `profile/[address]`).
- **`apps/mobile/components/index.ts`** - Added MiniAppIcon and MiniApp type to barrel exports.

## Acceptance criteria
- [x] Grid layout with app icon and name
- [x] Tapping an icon opens the mini app in the host container
- [x] Long-press shows an uninstall option
- [x] Empty state with a link to the discovery screen

Closes #289