### PR TITLE
fix(contracts): harden create_pool to reject duplicate admins

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     Vec,
 };
 
+// ── Blocking Storage Key ─────────────────────────────────────────────────────
+const BLOCKS: Symbol = symbol_short!("BLOCKS");
+
 // ── Storage Keys ────────────────────────────────────────────────────────────
 
 const POSTS: Symbol = symbol_short!("POSTS");
@@ -37,6 +40,8 @@ pub struct Profile {
 pub struct Pool {
     pub token: Address,
     pub balance: i128,
+    pub admins: Vec<Address>,
+    pub threshold: u32,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -162,6 +167,45 @@ impl LinkoraContract {
 
     // ── Community Token Pool ──────────────────────────────────────────────────
 
+    /// Create a named community pool with an explicit admin set.
+    /// Panics if `initial_admins` contains duplicate addresses.
+    pub fn create_pool(
+        env: Env,
+        creator: Address,
+        pool_id: Symbol,
+        token: Address,
+        initial_admins: Vec<Address>,
+        threshold: u32,
+    ) {
+        creator.require_auth();
+
+        // ── Reject duplicate admins ───────────────────────────────────────────
+        let mut seen: Map<Address, bool> = Map::new(&env);
+        for admin in initial_admins.iter() {
+            assert!(
+                !seen.contains_key(admin.clone()),
+                "duplicate admin in initial_admins"
+            );
+            seen.set(admin, true);
+        }
+
+        assert!(
+            threshold > 0 && threshold <= initial_admins.len(),
+            "invalid threshold"
+        );
+
+        let key = (POOLS, pool_id);
+        env.storage().persistent().set(
+            &key,
+            &Pool {
+                token,
+                balance: 0,
+                admins: initial_admins,
+                threshold,
+            },
+        );
+    }
+
     /// Deposit tokens into a named community pool.
     pub fn pool_deposit(
         env: Env,
@@ -179,7 +223,12 @@ impl LinkoraContract {
             .storage()
             .persistent()
             .get(&key)
-            .unwrap_or(Pool { token: token.clone(), balance: 0 });
+            .unwrap_or(Pool {
+                token: token.clone(),
+                balance: 0,
+                admins: Vec::new(&env),
+                threshold: 1,
+            });
         pool.balance += amount;
         env.storage().persistent().set(&key, &pool);
     }

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -90,3 +90,52 @@ fn test_pool_deposit_withdraw() {
     assert_eq!(pool.balance, 800);
     assert_eq!(TokenClient::new(&env, &token).balance(&user), 9_200);
 }
+
+#[test]
+fn test_create_pool_unique_admins_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
+    let token = setup_token(&env, &creator);
+    let pool_id = symbol_short!("mypool");
+
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin1);
+    admins.push_back(admin2);
+    admins.push_back(admin3);
+
+    // Should succeed — no duplicates
+    client.create_pool(&creator, &pool_id, &token, &admins, &2u32);
+
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.balance, 0);
+    assert_eq!(pool.threshold, 2);
+    assert_eq!(pool.admins.len(), 3);
+}
+
+#[test]
+#[should_panic(expected = "duplicate admin in initial_admins")]
+fn test_create_pool_duplicate_admins_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let admin1 = Address::generate(&env);
+    let token = setup_token(&env, &creator);
+    let pool_id = symbol_short!("badpool");
+
+    // admin1 appears twice — must panic
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin1.clone());
+    admins.push_back(admin1.clone());
+
+    client.create_pool(&creator, &pool_id, &token, &admins, &1u32);
+}


### PR DESCRIPTION
## Summary

Closes #323

Validates that `initial_admins` contains no duplicate addresses in `create_pool`, panicking with a descriptive error if any are found.

## Changes

### `src/lib.rs`
- Extended `Pool` struct with `admins: Vec<Address>` and `threshold: u32`
- Added `create_pool(creator, pool_id, token, initial_admins, threshold)`:
  - Iterates `initial_admins` into a `Map<Address, bool>` seen-set
  - Panics with `"duplicate admin in initial_admins"` on first repeated address
  - Also asserts `threshold > 0 && threshold <= initial_admins.len()`
- Updated `pool_deposit` fallback `Pool` initialiser to include empty `admins` and `threshold: 1`

### `src/test.rs`
- `test_create_pool_unique_admins_succeeds`: 3 unique admins → pool created, balance 0, threshold 2, admins.len() 3
- `test_create_pool_duplicate_admins_panics`: same admin twice → `#[should_panic(expected = "duplicate admin in initial_admins")]`
- All existing pool tests (`test_pool_deposit_withdraw`) still pass unchanged

## Acceptance Criteria
- [x] `create_pool` panics with a descriptive error if `initial_admins` contains duplicates
- [x] Test: duplicate admins → expect panic
- [x] Test: unique admins → pool created successfully
- [x] Existing pool tests still pass