### PR TITLE
[Mobile] Implement block/unblock and followers/following list screens

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -36,6 +36,29 @@ export default function ProfileScreen() {
             <Text style={styles.detailValue}>{rpcUrl}</Text>
           </View>
 
+          <View style={styles.linkRow}>
+            <TouchableOpacity
+              style={styles.linkButton}
+              onPress={() =>
+                router.push(
+                  `/profile/followers?address=${address}` as Parameters<typeof router.push>[0],
+                )
+              }
+            >
+              <Text style={styles.linkButtonText}>Followers</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.linkButton}
+              onPress={() =>
+                router.push(
+                  `/profile/following?address=${address}` as Parameters<typeof router.push>[0],
+                )
+              }
+            >
+              <Text style={styles.linkButtonText}>Following</Text>
+            </TouchableOpacity>
+          </View>
+
           <TouchableOpacity
             style={styles.button}
             onPress={() => router.push("/settings" as Parameters<typeof router.push>[0])}
@@ -113,6 +136,25 @@ const styles = StyleSheet.create({
     color: "#e2e8f0",
     fontSize: 12,
     lineHeight: 18,
+  },
+  linkRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 16,
+  },
+  linkButton: {
+    flex: 1,
+    backgroundColor: "#1e293b",
+    borderWidth: 1,
+    borderColor: "#334155",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  linkButtonText: {
+    color: "#e2e8f0",
+    fontWeight: "600",
+    fontSize: 14,
   },
   button: {
     backgroundColor: "#6366f1",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -162,6 +162,18 @@ export default function RootLayout() {
           options={{ href: null, headerShown: true, title: "Profile" }}
         />
         <Tabs.Screen name="pool/[id]" options={{ href: null, headerShown: true, title: "Pool" }} />
+        <Tabs.Screen
+          name="profile/followers"
+          options={{ href: null, headerShown: true, title: "Followers" }}
+        />
+        <Tabs.Screen
+          name="profile/following"
+          options={{ href: null, headerShown: true, title: "Following" }}
+        />
+        <Tabs.Screen
+          name="settings/blocked"
+          options={{ href: null, headerShown: true, title: "Blocked Users" }}
+        />
       </Tabs>
     </WalletProvider>
   );

--- a/apps/mobile/app/profile/followers.tsx
+++ b/apps/mobile/app/profile/followers.tsx
@@ -1,0 +1,128 @@
+import React, { useMemo } from "react";
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+import { UserListItem } from "../../components/UserListItem";
+import { useFollowers, type FollowUser } from "../../hooks/useFollowers";
+import { useTheme } from "../../theme/useTheme";
+
+type FollowersParams = {
+  address: string;
+};
+
+export default function FollowersScreen() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { address } = useLocalSearchParams<FollowersParams>();
+  const { users, loading, error, hasMore, loadMore, refresh } = useFollowers(address ?? "");
+
+  const handleUserPress = useMemo(
+    () => (user: FollowUser) => {
+      router.push(`/profile/${user.address}` as Parameters<typeof router.push>[0]);
+    },
+    [router],
+  );
+
+  if (loading && users.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={theme.colors.brand.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable
+          style={styles.retryButton}
+          onPress={refresh}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading followers"
+        >
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (users.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyTitle}>No followers</Text>
+        <Text style={styles.emptyText}>This user has no followers yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={users}
+      keyExtractor={(item) => item.address}
+      renderItem={({ item }) => (
+        <UserListItem user={item} onPress={handleUserPress} />
+      )}
+      onEndReached={loadMore}
+      onEndReachedThreshold={0.5}
+      onRefresh={refresh}
+      refreshing={loading}
+      ListFooterComponent={
+        hasMore && loading ? (
+          <ActivityIndicator
+            size="small"
+            color={theme.colors.brand.primary}
+            style={styles.footer}
+          />
+        ) : null
+      }
+      contentContainerStyle={styles.list}
+    />
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    list: {
+      backgroundColor: theme.colors.surface.background,
+    },
+    centered: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.background,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 24,
+      gap: 12,
+    },
+    errorText: {
+      color: theme.colors.semantic.error,
+      fontSize: 14,
+      textAlign: "center",
+    },
+    retryButton: {
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.brand.primary,
+      paddingHorizontal: 20,
+      paddingVertical: 10,
+    },
+    retryText: {
+      color: theme.colors.text.onBrand,
+      fontSize: 14,
+      fontWeight: "700",
+    },
+    emptyTitle: {
+      color: theme.colors.text.primary,
+      fontSize: 18,
+      fontWeight: "700",
+    },
+    emptyText: {
+      color: theme.colors.text.secondary,
+      fontSize: 14,
+      textAlign: "center",
+    },
+    footer: {
+      paddingVertical: 16,
+    },
+  });
+}

--- a/apps/mobile/app/profile/following.tsx
+++ b/apps/mobile/app/profile/following.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from "react";
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+import { UserListItem } from "../../components/UserListItem";
+import { useFollowing } from "../../hooks/useFollowing";
+import { useTheme } from "../../theme/useTheme";
+import type { FollowUser } from "../../hooks/useFollowers";
+
+type FollowingParams = {
+  address: string;
+};
+
+export default function FollowingScreen() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { address } = useLocalSearchParams<FollowingParams>();
+  const { users, loading, error, hasMore, loadMore, refresh } = useFollowing(address ?? "");
+
+  const handleUserPress = useMemo(
+    () => (user: FollowUser) => {
+      router.push(`/profile/${user.address}` as Parameters<typeof router.push>[0]);
+    },
+    [router],
+  );
+
+  if (loading && users.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={theme.colors.brand.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable
+          style={styles.retryButton}
+          onPress={refresh}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading following"
+        >
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (users.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyTitle}>Not following anyone</Text>
+        <Text style={styles.emptyText}>This user is not following anyone yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={users}
+      keyExtractor={(item) => item.address}
+      renderItem={({ item }) => (
+        <UserListItem user={item} onPress={handleUserPress} />
+      )}
+      onEndReached={loadMore}
+      onEndReachedThreshold={0.5}
+      onRefresh={refresh}
+      refreshing={loading}
+      ListFooterComponent={
+        hasMore && loading ? (
+          <ActivityIndicator
+            size="small"
+            color={theme.colors.brand.primary}
+            style={styles.footer}
+          />
+        ) : null
+      }
+      contentContainerStyle={styles.list}
+    />
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    list: {
+      backgroundColor: theme.colors.surface.background,
+    },
+    centered: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.background,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 24,
+      gap: 12,
+    },
+    errorText: {
+      color: theme.colors.semantic.error,
+      fontSize: 14,
+      textAlign: "center",
+    },
+    retryButton: {
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.brand.primary,
+      paddingHorizontal: 20,
+      paddingVertical: 10,
+    },
+    retryText: {
+      color: theme.colors.text.onBrand,
+      fontSize: 14,
+      fontWeight: "700",
+    },
+    emptyTitle: {
+      color: theme.colors.text.primary,
+      fontSize: 18,
+      fontWeight: "700",
+    },
+    emptyText: {
+      color: theme.colors.text.secondary,
+      fontSize: 14,
+      textAlign: "center",
+    },
+    footer: {
+      paddingVertical: 16,
+    },
+  });
+}

--- a/apps/mobile/app/settings/blocked.tsx
+++ b/apps/mobile/app/settings/blocked.tsx
@@ -1,19 +1,9 @@
-import React, { useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import React, { useMemo } from "react";
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
+import { useBlock } from "../../hooks/useBlock";
 import { useTheme } from "../../theme/useTheme";
-
-const INITIAL_BLOCKED = [
-  {
-    address: "GCFM4HKN3K2HMQY3X7T62JAT4B73W5C5V2F3KJDJQJY5M7WQ4H7W3ABC",
-    reason: "Spam replies",
-  },
-  {
-    address: "GBQ4BJEK4ABWQ5NEM7N5W3M7X4T2R6N3ZJYQ3FQW6N5K4JH6D2J7CDEF",
-    reason: "Harassment",
-  },
-];
 
 function shortAddress(address: string): string {
   return `${address.slice(0, 8)}…${address.slice(-6)}`;
@@ -23,7 +13,31 @@ export default function BlockedUsersScreen() {
   const router = useRouter();
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const [blocked, setBlocked] = useState(INITIAL_BLOCKED);
+  const { blocked, loading, error, blocking, unblockUser, refresh } = useBlock();
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <ActivityIndicator size="large" color={theme.colors.brand.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable
+          style={styles.retryButton}
+          onPress={refresh}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading blocked users"
+        >
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -44,10 +58,18 @@ export default function BlockedUsersScreen() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={`Unblock ${user.address}`}
-                onPress={() => setBlocked((current) => current.filter((item) => item.address !== user.address))}
-                style={styles.unblockButton}
+                disabled={blocking === user.address}
+                onPress={() => unblockUser(user.address)}
+                style={[
+                  styles.unblockButton,
+                  blocking === user.address && styles.unblockButtonDisabled,
+                ]}
               >
-                <Text style={styles.unblockText}>Unblock</Text>
+                {blocking === user.address ? (
+                  <ActivityIndicator size="small" color={theme.colors.semantic.error} />
+                ) : (
+                  <Text style={styles.unblockText}>Unblock</Text>
+                )}
               </Pressable>
             </View>
           </View>
@@ -76,6 +98,12 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.surface.background,
+    },
+    centered: {
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 24,
+      gap: 12,
     },
     content: {
       padding: 24,
@@ -130,10 +158,31 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
       borderRadius: 9999,
       paddingHorizontal: 14,
       paddingVertical: 8,
+      minWidth: 74,
+      alignItems: "center",
+    },
+    unblockButtonDisabled: {
+      opacity: 0.6,
     },
     unblockText: {
       color: theme.colors.semantic.error,
       fontSize: 12,
+      fontWeight: "700",
+    },
+    errorText: {
+      color: theme.colors.semantic.error,
+      fontSize: 14,
+      textAlign: "center",
+    },
+    retryButton: {
+      borderRadius: theme.radius.full,
+      backgroundColor: theme.colors.brand.primary,
+      paddingHorizontal: 20,
+      paddingVertical: 10,
+    },
+    retryText: {
+      color: theme.colors.text.onBrand,
+      fontSize: 14,
       fontWeight: "700",
     },
     empty: {

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -9,9 +9,12 @@ import {
   View,
 } from "react-native";
 
+import { useRouter } from "expo-router";
+
 import { useNetwork } from "../../hooks/useNetwork";
 
 export default function SettingsScreen(): JSX.Element {
+  const router = useRouter();
   const {
     network,
     rpcUrl,
@@ -128,6 +131,17 @@ export default function SettingsScreen(): JSX.Element {
         <View style={styles.codeBox}>
           <Text style={styles.code}>{contractId}</Text>
         </View>
+      </View>
+
+      <View style={styles.section}>
+        <Pressable
+          style={styles.secondaryButton}
+          onPress={() =>
+            router.push("/settings/blocked" as Parameters<typeof router.push>[0])
+          }
+        >
+          <Text style={styles.secondaryButtonText}>Manage blocked users</Text>
+        </Pressable>
       </View>
 
       <View style={styles.section}>

--- a/apps/mobile/components/UserListItem.tsx
+++ b/apps/mobile/components/UserListItem.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "../theme/useTheme";
+
+export interface UserItem {
+  address: string;
+  username: string;
+}
+
+interface UserListItemProps {
+  user: UserItem;
+  onPress: (user: UserItem) => void;
+}
+
+function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function UserListItem({ user, onPress }: UserListItemProps) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Pressable
+      style={styles.row}
+      onPress={() => onPress(user)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${user.username} profile`}
+    >
+      <View style={styles.avatar}>
+        <Text style={styles.avatarText}>{user.username.charAt(0).toUpperCase()}</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.title}>{user.username}</Text>
+        <Text style={styles.subtitle}>{shortAddress(user.address)}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    row: {
+      minHeight: 68,
+      flexDirection: "row",
+      alignItems: "center",
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.surface.border,
+    },
+    avatar: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: theme.colors.brand.primary,
+      alignItems: "center",
+      justifyContent: "center",
+      marginRight: 12,
+    },
+    avatarText: {
+      color: theme.colors.text.onBrand,
+      fontSize: 16,
+      fontWeight: "800",
+    },
+    content: {
+      flex: 1,
+    },
+    title: {
+      color: theme.colors.text.primary,
+      fontSize: 15,
+      fontWeight: "700",
+    },
+    subtitle: {
+      color: theme.colors.text.secondary,
+      fontSize: 12,
+      fontFamily: "monospace",
+      marginTop: 2,
+    },
+  });
+}

--- a/apps/mobile/components/index.ts
+++ b/apps/mobile/components/index.ts
@@ -3,6 +3,7 @@ export { PoolCard } from "./PoolCard";
 export { EmptyState } from "./EmptyState";
 export { SearchBar } from "./SearchBar";
 export { ProfileRow } from "./ProfileRow";
+export { UserListItem } from "./UserListItem";
 export { PoolRow } from "./PoolRow";
 export { WalletButton } from "./WalletButton";
 export { MiniAppIcon } from "./MiniAppIcon";

--- a/apps/mobile/hooks/useBlock.ts
+++ b/apps/mobile/hooks/useBlock.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface BlockedUser {
+  address: string;
+  reason: string;
+}
+
+const MOCK_BLOCKED: BlockedUser[] = [
+  {
+    address: "GCFM4HKN3K2HMQY3X7T62JAT4B73W5C5V2F3KJDJQJY5M7WQ4H7W3ABC",
+    reason: "Spam replies",
+  },
+  {
+    address: "GBQ4BJEK4ABWQ5NEM7N5W3M7X4T2R6N3ZJYQ3FQW6N5K4JH6D2J7CDEF",
+    reason: "Harassment",
+  },
+];
+
+async function fetchBlockedUsers(): Promise<BlockedUser[]> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 300));
+  return MOCK_BLOCKED;
+}
+
+async function blockUserRequest(_address: string): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+}
+
+async function unblockUserRequest(_address: string): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+}
+
+export interface UseBlockReturn {
+  blocked: BlockedUser[];
+  loading: boolean;
+  error: string | null;
+  blocking: string | null;
+  blockUser: (address: string) => Promise<void>;
+  unblockUser: (address: string) => Promise<void>;
+  refresh: () => void;
+}
+
+export function useBlock(): UseBlockReturn {
+  const [blocked, setBlocked] = useState<BlockedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [blocking, setBlocking] = useState<string | null>(null);
+
+  const loadBlocked = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const users = await fetchBlockedUsers();
+      setBlocked(users);
+    } catch {
+      setError("Failed to load blocked users. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadBlocked();
+  }, [loadBlocked]);
+
+  const blockUser = useCallback(async (address: string) => {
+    setBlocking(address);
+    setError(null);
+
+    try {
+      await blockUserRequest(address);
+      setBlocked((prev) => [...prev, { address, reason: "Blocked" }]);
+    } catch {
+      setError("Failed to block user. Please try again.");
+    } finally {
+      setBlocking(null);
+    }
+  }, []);
+
+  const unblockUser = useCallback(async (address: string) => {
+    setBlocking(address);
+    setError(null);
+
+    try {
+      await unblockUserRequest(address);
+      setBlocked((prev) => prev.filter((item) => item.address !== address));
+    } catch {
+      setError("Failed to unblock user. Please try again.");
+    } finally {
+      setBlocking(null);
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    loadBlocked();
+  }, [loadBlocked]);
+
+  return { blocked, loading, error, blocking, blockUser, unblockUser, refresh };
+}

--- a/apps/mobile/hooks/useFollowers.ts
+++ b/apps/mobile/hooks/useFollowers.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const PAGE_SIZE = 50;
+
+export interface FollowUser {
+  address: string;
+  username: string;
+}
+
+async function fetchFollowersPage(
+  address: string,
+  offset: number,
+  limit: number,
+): Promise<FollowUser[]> {
+  const ALL_FOLLOWERS: FollowUser[] = [
+    { address: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "stellar_dev" },
+    { address: "GXYZ9876543210ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "crypto_enthusiast" },
+    { address: "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "linkora_fan" },
+    { address: "GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "soroban_builder" },
+    { address: "GKLM5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "defi_explorer" },
+    { address: "GNOP1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "nft_collector" },
+    { address: "GQRS5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "dao_member" },
+    { address: "GTUV1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "web3_builder" },
+    { address: "GWXY5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "crypto_trader" },
+    { address: "GZAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "soroban_dev" },
+  ];
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 400));
+
+  return ALL_FOLLOWERS.slice(offset, offset + limit);
+}
+
+export interface UseFollowersReturn {
+  users: FollowUser[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+}
+
+export function useFollowers(address: string): UseFollowersReturn {
+  const [users, setUsers] = useState<FollowUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+
+  const offsetRef = useRef(0);
+  const loadingRef = useRef(false);
+
+  const load = useCallback(
+    async (offset: number, replace: boolean) => {
+      if (loadingRef.current) return;
+      loadingRef.current = true;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const fetched = await fetchFollowersPage(address, offset, PAGE_SIZE);
+        setUsers((prev) => (replace ? fetched : [...prev, ...fetched]));
+        setHasMore(fetched.length >= PAGE_SIZE);
+        offsetRef.current = offset + fetched.length;
+      } catch {
+        setError("Failed to load followers. Please try again.");
+      } finally {
+        setLoading(false);
+        loadingRef.current = false;
+      }
+    },
+    [address],
+  );
+
+  useEffect(() => {
+    offsetRef.current = 0;
+    load(0, true);
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      load(offsetRef.current, false);
+    }
+  }, [loading, hasMore, load]);
+
+  const refresh = useCallback(() => {
+    offsetRef.current = 0;
+    load(0, true);
+  }, [load]);
+
+  return { users, loading, error, hasMore, loadMore, refresh };
+}

--- a/apps/mobile/hooks/useFollowing.ts
+++ b/apps/mobile/hooks/useFollowing.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+import type { FollowUser } from "./useFollowers";
+
+const PAGE_SIZE = 50;
+
+async function fetchFollowingPage(
+  address: string,
+  offset: number,
+  limit: number,
+): Promise<FollowUser[]> {
+  const ALL_FOLLOWING: FollowUser[] = [
+    { address: "GBCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "rustacean" },
+    { address: "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "linkora_fan" },
+    { address: "GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "soroban_builder" },
+    { address: "GKLM5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "defi_explorer" },
+    { address: "GNOP1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", username: "nft_collector" },
+  ];
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 400));
+
+  return ALL_FOLLOWING.slice(offset, offset + limit);
+}
+
+export interface UseFollowingReturn {
+  users: FollowUser[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+}
+
+export function useFollowing(address: string): UseFollowingReturn {
+  const [users, setUsers] = useState<FollowUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+
+  const offsetRef = useRef(0);
+  const loadingRef = useRef(false);
+
+  const load = useCallback(
+    async (offset: number, replace: boolean) => {
+      if (loadingRef.current) return;
+      loadingRef.current = true;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const fetched = await fetchFollowingPage(address, offset, PAGE_SIZE);
+        setUsers((prev) => (replace ? fetched : [...prev, ...fetched]));
+        setHasMore(fetched.length >= PAGE_SIZE);
+        offsetRef.current = offset + fetched.length;
+      } catch {
+        setError("Failed to load following. Please try again.");
+      } finally {
+        setLoading(false);
+        loadingRef.current = false;
+      }
+    },
+    [address],
+  );
+
+  useEffect(() => {
+    offsetRef.current = 0;
+    load(0, true);
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      load(offsetRef.current, false);
+    }
+  }, [loading, hasMore, load]);
+
+  const refresh = useCallback(() => {
+    offsetRef.current = 0;
+    load(0, true);
+  }, [load]);
+
+  return { users, loading, error, hasMore, loadMore, refresh };
+}


### PR DESCRIPTION
## Summary

This PR implements two features for the mobile app:

### 1. Block/Unblock User (#262)
- **useBlock hook** - Provides block/unblock operations with loading states and blocked users list fetching
- **Blocked settings screen** - Rewritten to use the hook, with proper loading/error/empty states and loading indicators during unblock
- Added navigation link in settings to manage blocked users

### 2. Followers/Following List Screens (#261)
- **useFollowers hook** - Paginated followers list (offset + limit, max 50 per page)
- **useFollowing hook** - Paginated following list (offset + limit, max 50 per page)
- **UserListItem component** - Reusable row showing avatar + username + address
- **Followers screen** - Paginated FlatList with pull-to-refresh
- **Following screen** - Paginated FlatList with pull-to-refresh
- Added navigation links in the profile tab screen
- Registered all new routes in the root layout

### Notes
- All hooks follow the existing mock-based pattern used throughout the mobile app
- Follows the app's theme system (useTheme() + useMemo styles)
- Handles loading, error, and empty states
- Tapping a user row navigates to their profile

Closes #261
Closes #262