### PR TITLE
[Mobile] Build Profile screen

### DIFF
--- a/apps/mobile/app/profile/[address].tsx
+++ b/apps/mobile/app/profile/[address].tsx
@@ -1,26 +1,85 @@
 import React, { useMemo } from "react";
-import { Text, StyleSheet, ScrollView } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { useTheme } from "../../theme/useTheme";
+import { useProfile } from "../../hooks/useProfile";
+import { useFeed } from "../../hooks/useFeed";
+import { useWallet } from "../../hooks/useWallet";
+import ProfileHeader from "../../components/ProfileHeader";
+import { PostCard } from "../../components/PostCard";
 
 type ProfileParams = {
   address: string;
 };
 
 export default function ProfileDetailScreen() {
+  const router = useRouter();
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { address } = useLocalSearchParams<ProfileParams>();
+  const { address: me } = useWallet();
+
+  const { profile, loading, error, followerCount, followingCount, isFollowing, toggleFollow, refresh } =
+    useProfile(address ?? "");
+
+  const { posts, loading: postsLoading, refresh: refreshPosts } = useFeed();
+
+  const userPosts = posts.filter((p) => p.author === address);
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color={theme.colors.brand.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable onPress={refresh} style={styles.retryButton} accessibilityRole="button">
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <Text style={styles.label}>Profile</Text>
-      <Text style={styles.address}>
-        {address ? `${address.slice(0, 8)}…${address.slice(-6)}` : "—"}
-      </Text>
-      <Text style={styles.placeholder}>Profile detail coming soon.</Text>
-    </ScrollView>
+    <View style={styles.container}>
+      {profile && (
+        <ProfileHeader
+          profile={profile}
+          followerCount={followerCount}
+          followingCount={followingCount}
+          isFollowing={isFollowing}
+          isOwnProfile={me === address}
+          onFollowersPress={() => router.push(`/profile/followers?address=${address}` as Parameters<typeof router.push>[0])}
+          onFollowingPress={() => router.push(`/profile/following?address=${address}` as Parameters<typeof router.push>[0])}
+          onEditPress={() => router.push("/settings" as Parameters<typeof router.push>[0])}
+          onToggleFollow={toggleFollow}
+        />
+      )}
+
+      <FlatList
+        data={userPosts}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => <PostCard post={item} />}
+        onRefresh={() => {
+          refreshPosts();
+          refresh();
+        }}
+        refreshing={postsLoading}
+        contentContainerStyle={styles.list}
+        ListEmptyComponent={() => (
+          <View style={styles.empty}>
+            <Text style={styles.emptyTitle}>No posts yet</Text>
+            <Text style={styles.emptyText}>This user hasn't posted anything.</Text>
+          </View>
+        )}
+      />
+    </View>
   );
 }
 
@@ -30,26 +89,42 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
       flex: 1,
       backgroundColor: theme.colors.surface.background,
     },
-    content: {
+    centered: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: theme.colors.surface.background,
+    },
+    errorText: {
+      color: theme.colors.semantic.error,
+    },
+    retryButton: {
+      marginTop: 12,
+      backgroundColor: theme.colors.brand.primary,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      borderRadius: theme.radius.full,
+    },
+    retryText: {
+      color: theme.colors.text.onBrand,
+      fontWeight: "700",
+    },
+    list: {
+      paddingBottom: 48,
+      backgroundColor: theme.colors.surface.background,
+    },
+    empty: {
       padding: 24,
+      alignItems: "center",
     },
-    label: {
-      fontSize: 12,
-      color: theme.colors.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: 1,
-      marginBottom: 4,
-    },
-    address: {
+    emptyTitle: {
+      color: theme.colors.text.primary,
       fontSize: 16,
       fontWeight: "700",
-      color: theme.colors.text.primary,
-      marginBottom: 16,
-      fontFamily: "monospace",
     },
-    placeholder: {
-      fontSize: 14,
+    emptyText: {
       color: theme.colors.text.secondary,
+      marginTop: 8,
     },
   });
 }

--- a/apps/mobile/components/ProfileHeader.tsx
+++ b/apps/mobile/components/ProfileHeader.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "../theme/useTheme";
+
+export interface ProfileData {
+  address: string;
+  username?: string | null;
+  bio?: string | null;
+}
+
+interface Props {
+  profile: ProfileData;
+  followerCount: number;
+  followingCount: number;
+  isFollowing: boolean;
+  isOwnProfile?: boolean;
+  onFollowersPress: () => void;
+  onFollowingPress: () => void;
+  onEditPress: () => void;
+  onToggleFollow: () => void;
+}
+
+export default function ProfileHeader({
+  profile,
+  followerCount,
+  followingCount,
+  isFollowing,
+  isOwnProfile,
+  onFollowersPress,
+  onFollowingPress,
+  onEditPress,
+  onToggleFollow,
+}: Props) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const shortAddress = `${profile.address.slice(0, 8)}…${profile.address.slice(-6)}`;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <View style={styles.avatar}>
+          <Text style={styles.avatarText}>{(profile.username ?? "").charAt(0).toUpperCase() || "?"}</Text>
+        </View>
+        <View style={styles.meta}>
+          <Text style={styles.username}>{profile.username ?? shortAddress}</Text>
+          <Text style={styles.address}>{shortAddress}</Text>
+          {profile.bio ? <Text style={styles.bio}>{profile.bio}</Text> : null}
+        </View>
+        <View style={styles.actionWrap}>
+          {isOwnProfile ? (
+            <Pressable style={styles.editButton} onPress={onEditPress} accessibilityRole="button">
+              <Text style={styles.editText}>Edit</Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              style={[styles.followButton, isFollowing ? styles.following : null]}
+              onPress={onToggleFollow}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.followText, isFollowing ? styles.followingText : null]}>
+                {isFollowing ? "Following" : "Follow"}
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+
+      <View style={styles.countsRow}>
+        <Pressable onPress={onFollowersPress} accessibilityRole="button" style={styles.countItem}>
+          <Text style={styles.countNumber}>{followerCount}</Text>
+          <Text style={styles.countLabel}>Followers</Text>
+        </Pressable>
+        <Pressable onPress={onFollowingPress} accessibilityRole="button" style={styles.countItem}>
+          <Text style={styles.countNumber}>{followingCount}</Text>
+          <Text style={styles.countLabel}>Following</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
+  return StyleSheet.create({
+    container: {
+      paddingHorizontal: 16,
+      paddingVertical: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.surface.border,
+      backgroundColor: theme.colors.surface.background,
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    avatar: {
+      width: 72,
+      height: 72,
+      borderRadius: 36,
+      backgroundColor: theme.colors.brand.primary,
+      alignItems: "center",
+      justifyContent: "center",
+      marginRight: 12,
+    },
+    avatarText: {
+      color: theme.colors.text.onBrand,
+      fontSize: 28,
+      fontWeight: "800",
+    },
+    meta: {
+      flex: 1,
+    },
+    username: {
+      color: theme.colors.text.primary,
+      fontSize: 18,
+      fontWeight: "800",
+    },
+    address: {
+      color: theme.colors.text.secondary,
+      fontFamily: "monospace",
+      marginTop: 2,
+    },
+    bio: {
+      color: theme.colors.text.secondary,
+      marginTop: 8,
+    },
+    actionWrap: {
+      marginLeft: 8,
+    },
+    editButton: {
+      backgroundColor: theme.colors.surface.elevated,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      borderRadius: theme.radius.full,
+    },
+    editText: {
+      color: theme.colors.text.primary,
+      fontWeight: "700",
+    },
+    followButton: {
+      backgroundColor: theme.colors.brand.primary,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      borderRadius: theme.radius.full,
+    },
+    following: {
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.surface.border,
+    },
+    followText: {
+      color: theme.colors.text.onBrand,
+      fontWeight: "700",
+    },
+    followingText: {
+      color: theme.colors.text.primary,
+    },
+    countsRow: {
+      flexDirection: "row",
+      marginTop: 12,
+      gap: 24,
+    },
+    countItem: {
+      alignItems: "center",
+    },
+    countNumber: {
+      color: theme.colors.text.primary,
+      fontWeight: "800",
+      fontSize: 15,
+    },
+    countLabel: {
+      color: theme.colors.text.secondary,
+      fontSize: 12,
+      marginTop: 2,
+    },
+  });
+}

--- a/apps/mobile/context/WalletContext.tsx
+++ b/apps/mobile/context/WalletContext.tsx
@@ -44,6 +44,8 @@ interface WalletConnectLike {
   disconnect: () => Promise<void>;
   getPublicKey?: () => Promise<string>;
   isConnected?: () => Promise<boolean>;
+  signTransaction?: (payload: { txXdr: string }) => Promise<any>;
+  signAndSubmitTransaction?: (payload: { txXdr: string; rpcUrl?: string }) => Promise<any>;
 }
 
 async function createWalletConnectAdapter(): Promise<WalletConnectLike> {
@@ -55,8 +57,9 @@ async function createWalletConnectAdapter(): Promise<WalletConnectLike> {
   let client: Awaited<ReturnType<typeof SignClient.init>> | null = null;
   let topic: string | null = null;
   let currentAddress: string | null = null;
+  let connectedNetwork: NetworkPreset | null = null;
 
-  return {
+  const adapter: WalletConnectLike = {
     async connect(network: NetworkPreset) {
       if (!projectId) {
         throw new Error("WalletConnect project id not configured");
@@ -84,100 +87,95 @@ async function createWalletConnectAdapter(): Promise<WalletConnectLike> {
         },
       });
 
-      if (uri) {
-        await Linking.openURL(uri);
-      }
+      if (uri) await Linking.openURL(uri);
 
       const session = await approval();
       topic = session.topic;
       const account = session.namespaces.stellar?.accounts?.[0];
       currentAddress = account?.split(":").pop() ?? null;
+      connectedNetwork = network;
 
-      if (!currentAddress) {
-        throw new Error("No Stellar account returned from WalletConnect");
-      }
+      if (!currentAddress) throw new Error("No Stellar account returned from WalletConnect");
 
       return { publicKey: currentAddress };
     },
+
     async disconnect() {
       if (client && topic) {
-        await client.disconnect({
-          topic,
-          reason: { code: 6000, message: "User disconnected" },
-        });
+        await client.disconnect({ topic, reason: { code: 6000, message: "User disconnected" } });
       }
       topic = null;
       currentAddress = null;
+      connectedNetwork = null;
     },
+
     async getPublicKey() {
-      if (!currentAddress) {
-        throw new Error("WalletConnect is not connected");
-      }
+      if (!currentAddress) throw new Error("WalletConnect is not connected");
       return currentAddress;
     },
+
     async isConnected() {
       return Boolean(currentAddress);
     },
+
+    async signTransaction({ txXdr }: { txXdr: string }) {
+      if (!client || !topic || !connectedNetwork) throw new Error("Wallet not connected");
+
+      const request = {
+        topic,
+        chain: connectedNetwork.chain,
+        request: {
+          method: "stellar_signXDR",
+          params: { txXdr },
+        },
+      } as any;
+
+      const res = await client.request(request);
+      return res;
+    },
+
+    async signAndSubmitTransaction({ txXdr, rpcUrl }: { txXdr: string; rpcUrl?: string }) {
+      const signed = await adapter.signTransaction?.({ txXdr });
+      const signedXdr = signed?.signedTxXdr ?? signed?.signedXdr ?? signed?.signed;
+      if (!signedXdr) throw new Error("Wallet did not return signed transaction XDR");
+
+      const { rpc } = await import("@stellar/stellar-sdk");
+      const server = new rpc.Server(rpcUrl ?? connectedNetwork?.rpcUrl ?? "");
+      const submitRes = await server.submitTransaction(signedXdr);
+      return submitRes;
+    },
   };
+
+  return adapter;
 }
 
 declare global {
-  // Test/runtime escape hatch for environments where the optional wallet kit
-  // package is intentionally not installed.
   // eslint-disable-next-line no-var, @typescript-eslint/no-explicit-any
   var __LINKORA_WALLET_KIT__: any | undefined;
 }
 
 export interface WalletContextType {
-  /** Current connection state machine value */
   state: WalletState;
-  /** Wallet address and network info */
   wallet: WalletInfo;
-  /** Active network preference */
   network: WalletNetwork;
-  /** Last error message, if any */
   error: string | null;
-  /** Initiate wallet connection */
   connect: (provider?: WalletProviderKind) => Promise<void>;
-  /** Disconnect and clear persisted state */
   disconnect: () => Promise<void>;
-  /** Re-check connection state (e.g. after app foreground) */
   refresh: () => Promise<void>;
-  /** Update the active network preference */
   setNetwork: (network: WalletNetwork) => void;
 }
 
-// ---------------------------------------------------------------------------
-// Context
-// ---------------------------------------------------------------------------
-
 const WalletContext = createContext<WalletContextType | null>(null);
 
-// ---------------------------------------------------------------------------
-// Provider
-// ---------------------------------------------------------------------------
-
-interface WalletProviderProps {
-  children: ReactNode;
-}
-
-export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
+export function WalletProvider({ children }: { children: ReactNode }): JSX.Element {
   const { network: selectedNetwork } = useNetworkContext();
   const [state, setState] = useState<WalletState>("loading");
   const [network, setNetwork] = useState<WalletNetwork>("TESTNET");
-  const [wallet, setWallet] = useState<WalletInfo>({
-    address: null,
-    network: null,
-    provider: null,
-  });
+  const [wallet, setWallet] = useState<WalletInfo>({ address: null, network: null, provider: null });
   const [error, setError] = useState<string | null>(null);
 
-  // Lazy-loaded WalletConnect-compatible wallet kit instance
-  const [walletKit, setWalletKit] = useState<WalletConnectLike | null>(
-    () => globalThis.__LINKORA_WALLET_KIT__ ?? null
-  );
+  const [walletKit, setWalletKit] = useState<WalletConnectLike | null>(() => globalThis.__LINKORA_WALLET_KIT__ ?? null);
 
-  // Initialize the WalletConnect adapter on mount.
   useEffect(() => {
     let cancelled = false;
 
@@ -189,7 +187,12 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
         }
 
         if (!cancelled) {
-          setWalletKit(await createWalletConnectAdapter());
+          const adapter = await createWalletConnectAdapter();
+          // Expose globally for other modules that expect a wallet kit
+          // (tests or mini-app bridges may rely on this global).
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (globalThis as any).__LINKORA_WALLET_KIT__ = adapter;
+          setWalletKit(adapter);
         }
       } catch {
         if (!cancelled) {
@@ -207,7 +210,7 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
 
   const importFreighterApi = useCallback(async () => {
     const loader = new Function("specifier", "return import(specifier)") as (
-      specifier: string
+      specifier: string,
     ) => Promise<Record<string, unknown>>;
     return loader("@stellar/freighter-api");
   }, []);
@@ -215,22 +218,14 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
   const requestFreighterAddress = useCallback(async (): Promise<string> => {
     const freighter = await importFreighterApi();
 
-    const available =
-      typeof freighter.isConnected === "function" ? await freighter.isConnected() : true;
+    const available = typeof freighter.isConnected === "function" ? await freighter.isConnected() : true;
 
-    if (!available) {
-      throw new Error("Freighter is not available");
-    }
+    if (!available) throw new Error("Freighter is not available");
 
     if (typeof freighter.requestAccess === "function") {
       const result = await freighter.requestAccess();
       if (typeof result === "string") return result;
-      if (
-        result &&
-        typeof result === "object" &&
-        "address" in result &&
-        typeof result.address === "string"
-      ) {
+      if (result && typeof result === "object" && "address" in result && typeof result.address === "string") {
         return result.address;
       }
     }
@@ -243,12 +238,7 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
     if (typeof freighter.getAddress === "function") {
       const result = await freighter.getAddress();
       if (typeof result === "string") return result;
-      if (
-        result &&
-        typeof result === "object" &&
-        "address" in result &&
-        typeof result.address === "string"
-      ) {
+      if (result && typeof result === "object" && "address" in result && typeof result.address === "string") {
         return result.address;
       }
     }
@@ -256,7 +246,6 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
     throw new Error("No address returned from Freighter");
   }, [importFreighterApi]);
 
-  // Check persisted connection state once wallet kit is ready
   const checkConnectionState = useCallback(async () => {
     if (!walletKit) return;
 
@@ -268,27 +257,18 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
       const storedConn = await getConnectionState();
 
       if (storedAddress && storedConn) {
-        const isConnected: boolean = walletKit.isConnected
-          ? await walletKit.isConnected()
-          : Boolean(storedAddress);
+        const isConnected: boolean = walletKit.isConnected ? await walletKit.isConnected() : Boolean(storedAddress);
 
         if (isConnected) {
-          const currentAddress: string = walletKit.getPublicKey
-            ? await walletKit.getPublicKey()
-            : storedAddress;
+          const currentAddress: string = walletKit.getPublicKey ? await walletKit.getPublicKey() : storedAddress;
 
           if (currentAddress === storedAddress) {
-            setWallet({
-              address: currentAddress,
-              network: selectedNetwork.id,
-              provider: "walletconnect",
-            });
+            setWallet({ address: currentAddress, network: selectedNetwork.id, provider: "walletconnect" });
             setState("connected");
             return;
           }
         }
 
-        // Stale — clear storage
         await Promise.all([deleteWalletAddress(), deleteConnectionState()]);
       }
 
@@ -298,15 +278,12 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
       setState("error");
       setError(err instanceof Error ? err.message : "Unknown error");
     }
-  }, [walletKit, selectedNetwork.label]);
+  }, [walletKit, selectedNetwork.id]);
 
   useEffect(() => {
-    if (walletKit) {
-      checkConnectionState();
-    }
+    if (walletKit) checkConnectionState();
   }, [walletKit, checkConnectionState]);
 
-  // Connect
   const connect = useCallback(
     async (provider: WalletProviderKind = "walletconnect") => {
       try {
@@ -318,12 +295,9 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
         if (provider === "freighter") {
           address = await requestFreighterAddress();
         } else {
-          if (!walletKit) {
-            throw new Error("WalletConnect is not available");
-          }
+          if (!walletKit) throw new Error("WalletConnect is not available");
 
-          const result: { publicKey?: string; address?: string } =
-            await walletKit.connect(selectedNetwork);
+          const result: { publicKey?: string; address?: string } = await walletKit.connect(selectedNetwork);
           address = result.publicKey ?? result.address ?? null;
 
           if (typeof walletKit.getPublicKey === "function") {
@@ -331,16 +305,9 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
           }
         }
 
-        if (!address) {
-          throw new Error("No address returned from wallet");
-        }
+        if (!address) throw new Error("No address returned from wallet");
 
-        const connState: StoredConnectionState = {
-          connected: true,
-          address,
-          timestamp: Date.now(),
-        };
-
+        const connState: StoredConnectionState = { connected: true, address, timestamp: Date.now() };
         await Promise.all([setWalletAddress(address), setConnectionState(connState)]);
 
         setWallet({ address, network: selectedNetwork.id, provider });
@@ -351,18 +318,15 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
         setWallet({ address: null, network: null, provider: null });
       }
     },
-    [requestFreighterAddress, selectedNetwork, walletKit]
+    [requestFreighterAddress, selectedNetwork, walletKit],
   );
 
-  // Disconnect
   const disconnect = useCallback(async () => {
     try {
       setError(null);
-      if (walletKit) {
-        await walletKit.disconnect();
-      }
+      if (walletKit) await walletKit.disconnect();
     } catch {
-      // Ignore disconnect errors — always clear local state
+      // ignore
     } finally {
       await Promise.all([deleteWalletAddress(), deleteConnectionState()]);
       setWallet({ address: null, network: null, provider: null });
@@ -376,40 +340,18 @@ export function WalletProvider({ children }: WalletProviderProps): JSX.Element {
 
   useEffect(() => {
     if (wallet.address) {
-      setWallet((current) => ({
-        ...current,
-        network: selectedNetwork.id,
-      }));
+      setWallet((current) => ({ ...current, network: selectedNetwork.id }));
     }
   }, [selectedNetwork.id, wallet.address]);
 
-  const value: WalletContextType = {
-    state,
-    wallet,
-    network,
-    error,
-    connect,
-    disconnect,
-    refresh,
-    setNetwork,
-  };
+  const value: WalletContextType = { state, wallet, network, error, connect, disconnect, refresh, setNetwork };
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
-/**
- * Returns wallet state and actions.
- * Must be used inside <WalletProvider>.
- */
 export function useWalletContext(): WalletContextType {
   const ctx = useContext(WalletContext);
-  if (!ctx) {
-    throw new Error("useWalletContext must be used within a WalletProvider");
-  }
+  if (!ctx) throw new Error("useWalletContext must be used within a WalletProvider");
   return ctx;
 }
 

--- a/apps/mobile/hooks/useProfile.ts
+++ b/apps/mobile/hooks/useProfile.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { LinkoraClient } from "../../../packages/sdk/src/client";
+
+import { useNetwork } from "./useNetwork";
+import { useFollowers } from "./useFollowers";
+import { useFollowing } from "./useFollowing";
+import { useWallet } from "./useWallet";
+import { useToast } from "../context/ToastContext";
+
+export interface Profile {
+  address: string;
+  username?: string | null;
+  bio?: string | null;
+}
+
+export function useProfile(address: string) {
+  const { rpcUrl, contractId } = useNetwork();
+  const { address: me } = useWallet();
+
+  const clientRef = useRef<LinkoraClient | null>(null);
+  clientRef.current = clientRef.current ?? new LinkoraClient({ contractId, rpcUrl });
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState<boolean>(!!address);
+  const [error, setError] = useState<string | null>(null);
+
+  const followers = useFollowers(address ?? "");
+  const following = useFollowing(address ?? "");
+
+  const myFollowing = useFollowing(me ?? "");
+
+  const followerCount = followers.users.length;
+  const followingCount = following.users.length;
+
+  const isFollowing = useMemo(() => {
+    if (!me) return false;
+    return myFollowing.users.some((u) => u.address === address);
+  }, [me, myFollowing.users, address]);
+
+  const fetchProfile = useCallback(async () => {
+    if (!address) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const client = clientRef.current as LinkoraClient;
+      const p = await client.getProfile(address);
+      setProfile(
+        p
+          ? {
+              address,
+              username: p.username ?? null,
+              bio: (p.bio as string) ?? null,
+            }
+          : null,
+      );
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to load profile", e);
+      setError("Failed to load profile.");
+    } finally {
+      setLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const { showPending, showSuccess, showError } = useToast();
+
+  const toggleFollow = useCallback(async () => {
+    if (!address) return;
+    if (!me) {
+      showError("Connect your wallet to follow users.");
+      return;
+    }
+
+    const client = clientRef.current as LinkoraClient;
+    if (!client) {
+      showError("SDK client not available");
+      return;
+    }
+
+    const txXdr = isFollowing ? client.unfollow(me, address) : client.follow(me, address);
+
+    showPending();
+
+    try {
+      // Try to use an injected wallet kit that can sign/submit
+      const kit = (globalThis as any).__LINKORA_WALLET_KIT__;
+
+      if (kit && typeof kit.signAndSubmitTransaction === "function") {
+        const res = await kit.signAndSubmitTransaction({ txXdr });
+        const txHash = res?.hash ?? res?.txHash ?? "";
+        showSuccess(txHash);
+      } else if (kit && typeof kit.signTransaction === "function") {
+        const signed = await kit.signTransaction({ txXdr });
+        const signedXdr = signed?.signedTxXdr ?? signed?.signedXdr ?? signed?.signedTx;
+        if (!signedXdr) throw new Error("Wallet did not return signed transaction XDR");
+
+        const { rpc } = await import("@stellar/stellar-sdk");
+        const server = new rpc.Server(rpcUrl);
+        const submitRes = await server.submitTransaction(signedXdr);
+        const txHash = submitRes?.hash ?? "";
+        showSuccess(txHash);
+      } else {
+        throw new Error("Wallet signing not available in this environment");
+      }
+
+      // refresh followers/following after success
+      followers.refresh();
+      following.refresh();
+      myFollowing.refresh();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to submit transaction";
+      showError(msg);
+    }
+  }, [address, me, isFollowing, rpcUrl, showError, showPending, showSuccess, followers, following, myFollowing]);
+
+  const refresh = useCallback(() => {
+    fetchProfile();
+    // trigger followers/following refresh by calling their refresh methods if available
+    followers.refresh();
+    following.refresh();
+    myFollowing.refresh();
+  }, [fetchProfile, followers, following, myFollowing]);
+
+  return {
+    profile,
+    loading,
+    error,
+    followerCount,
+    followingCount,
+    isFollowing,
+    toggleFollow,
+    refresh,
+  } as const;
+}


### PR DESCRIPTION

## Summary

Implemented the mobile Profile screen with avatar, username, and tappable follower/following counts. Own profiles show an Edit button; others show Follow/Unfollow backed by wallet signing. Profile data loads via `get_profile`, and follow/unfollow actions go through `WalletContext`. Updated todo list. 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Contract change (logic, storage, or API)
- [ ] Documentation update
- [x] Refactor / chore

## Testing Done

Started the app in Expo, connected a wallet via WalletConnect, opened a profile page and verified: profile loaded from the contract, avatar/username/bio shown, follower/following counts are tappable (navigate), own profile shows Edit, other profiles show Follow which triggered the wallet signing flow and a success/error toast, and the user's posts list displays.

- [ ] `cargo test` passes
- [ ] New tests added for changed behaviour
- [ ] Manually verified on Testnet (if applicable)

## Checklist

- [x] Changes are focused — one concern per PR
- [ ] If a contract function was added or changed, the README API table is updated
- [x] No unresolved merge conflicts
- [x] No secrets or private keys committed

## Related Issue

Closes #258 
