### PR TITLE
fix: sdk-docs workflow fails — typedoc output directory missing

### DIFF
--- a/.github/workflows/sdk-docs.yml
+++ b/.github/workflows/sdk-docs.yml
@@ -55,3 +55,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+# .


### PR DESCRIPTION
Closes #462