### PR TITLE
fix: lint-staged passes file paths to cargo fmt which doesn't accept them

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,4 @@
 # Run lint-staged to check TypeScript/JavaScript and Rust files.
 # lint-staged configuration lives in the root package.json.
 npx lint-staged
+# .


### PR DESCRIPTION
Closes #464