### PR TITLE
Created edit profile screen

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -61,6 +61,12 @@ export default function ProfileScreen() {
 
           <TouchableOpacity
             style={styles.button}
+            onPress={() => router.push("/profile/edit" as Parameters<typeof router.push>[0])}
+          >
+            <Text style={styles.buttonText}>Edit profile</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.button}
             onPress={() => router.push("/settings" as Parameters<typeof router.push>[0])}
           >
             <Text style={styles.buttonText}>Open settings</Text>

--- a/apps/mobile/app/profile/edit.tsx
+++ b/apps/mobile/app/profile/edit.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+
+import { useToast } from "../../context/ToastContext";
+import { useWallet } from "../../hooks/useWallet";
+
+const USERNAME_RE = /^[a-zA-Z0-9_]{3,32}$/;
+
+async function setProfileTransaction(
+  _user: string,
+  _username: string,
+  _creatorToken: string
+): Promise<string> {
+  // Replace with SDK-backed set_profile submission once signing is wired.
+  await new Promise<void>((resolve) => setTimeout(resolve, 800));
+  return `mock_tx_${Date.now().toString(36)}`;
+}
+
+function validateUsername(value: string): string | null {
+  if (!value.trim()) return "Username is required.";
+  if (!USERNAME_RE.test(value)) {
+    return "Username must be 3–32 characters: letters, numbers, or underscores only.";
+  }
+  return null;
+}
+
+export default function EditProfileScreen() {
+  const router = useRouter();
+  const { address, connected } = useWallet();
+  const { showPending, showSuccess, showError } = useToast();
+
+  const [username, setUsername] = useState("");
+  const [creatorToken, setCreatorToken] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+
+  const handleUsernameChange = (value: string) => {
+    setUsername(value);
+    if (usernameError) {
+      setUsernameError(validateUsername(value));
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!connected || !address) {
+      showError("Connect your wallet to edit your profile.");
+      return;
+    }
+
+    const error = validateUsername(username);
+    if (error) {
+      setUsernameError(error);
+      return;
+    }
+
+    setSubmitting(true);
+    showPending();
+
+    try {
+      const txHash = await setProfileTransaction(address, username.trim(), creatorToken.trim());
+      showSuccess(txHash);
+      router.back();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to update profile.";
+      showError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.heading}>Edit Profile</Text>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Username</Text>
+          <TextInput
+            style={[styles.input, usernameError ? styles.inputError : null]}
+            placeholder="e.g. satoshi_nakamoto"
+            placeholderTextColor="#64748b"
+            value={username}
+            onChangeText={handleUsernameChange}
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!submitting}
+            accessibilityLabel="Username"
+          />
+          {usernameError ? <Text style={styles.errorText}>{usernameError}</Text> : null}
+          <Text style={styles.hint}>3–32 characters: letters, numbers, or underscores.</Text>
+        </View>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Creator token address</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            placeholderTextColor="#64748b"
+            value={creatorToken}
+            onChangeText={setCreatorToken}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            editable={!submitting}
+            accessibilityLabel="Creator token address"
+          />
+          <Text style={styles.hint}>Stellar contract address for your creator token.</Text>
+        </View>
+
+        <TouchableOpacity
+          style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+          onPress={handleSubmit}
+          disabled={submitting}
+          accessibilityLabel="Save profile"
+        >
+          {submitting ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text style={styles.submitText}>Save changes</Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.cancelButton}
+          onPress={() => router.back()}
+          disabled={submitting}
+        >
+          <Text style={styles.cancelText}>Cancel</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+  },
+  scrollContent: {
+    padding: 24,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#f1f5f9",
+    marginBottom: 28,
+  },
+  fieldGroup: {
+    marginBottom: 24,
+  },
+  label: {
+    color: "#94a3b8",
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: "#1e293b",
+    borderRadius: 12,
+    padding: 16,
+    fontSize: 15,
+    color: "#f1f5f9",
+    borderWidth: 1,
+    borderColor: "#334155",
+  },
+  inputError: {
+    borderColor: "#f87171",
+  },
+  errorText: {
+    color: "#f87171",
+    fontSize: 12,
+    marginTop: 6,
+  },
+  hint: {
+    color: "#64748b",
+    fontSize: 12,
+    marginTop: 6,
+  },
+  submitButton: {
+    backgroundColor: "#6366f1",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  submitButtonDisabled: {
+    opacity: 0.6,
+  },
+  submitText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  cancelButton: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: "#334155",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  cancelText: {
+    color: "#e2e8f0",
+    fontWeight: "600",
+    fontSize: 15,
+  },
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -368,6 +368,17 @@ export class LinkoraClient {
   }
 
   /**
+   * Builds an XDR envelope for setting a user profile
+   * @param user - The user's Stellar address
+   * @param username - The desired username (3–32 alphanumeric or _ characters)
+   * @param creatorToken - The creator token contract address
+   * @returns The base64-encoded XDR envelope
+   */
+  setProfile(user: string, username: string, creatorToken: string): string {
+    return this.buildTx("set_profile", scvAddress(user), scvString(username), scvAddress(creatorToken));
+  }
+
+  /**
    * Builds an XDR envelope for blocking a user
    * @param blocker - The blocker's Stellar address
    * @param blocked - The address to block


### PR DESCRIPTION
## Summary

- **New screen** `apps/mobile/app/profile/edit.tsx` — lets a connected wallet holder update their username and creator token address via `set_profile`
- **Username validation** enforces the 3–32 alphanumeric-or-underscore rule (`/^[a-zA-Z0-9_]{3,32}$/`) with inline error feedback
- **Transaction flow** shows a pending toast on submit, a success toast (with tx hash) on confirmation, and an error toast on failure; navigates back to the profile screen on success
- **SDK** — added `LinkoraClient.setProfile(user, username, creatorToken)` XDR builder to `packages/sdk/src/client.ts` matching the contract signature `set_profile(env, user, username, creator_token)`
- **Profile tab** — wired up an "Edit profile" button that routes to `/profile/edit`

## Notes

The `setProfileTransaction` helper in `edit.tsx` is currently mocked (mirrors the `useLike` / `usePoolDeposit` pattern already in the codebase). It should be replaced with the real SDK call + wallet signing once the signing layer is wired up.

## Test plan

- [ ] Navigate to the Profile tab while connected — "Edit profile" button is visible
- [ ] Tap "Edit profile" — screen opens with username and creator token fields
- [ ] Submit with an empty username → inline error message appears, no transaction fires
- [ ] Submit with `ab` (2 chars) or `abc def` (space) → validation blocks submission
- [ ] Submit with a valid username (e.g. `satoshi_42`) → pending toast appears, then success toast, then navigates back
- [ ] Tap Cancel → returns to profile screen without submitting
- [ ] Navigate while disconnected → "Edit profile" is not reachable (button only renders when `connected && address`)

Closes #259 