### PR TITLE
feat(indexer): exactly-once pipeline, backpressure, WebSocket fanout, gap detection

### DIFF
--- a/docs/indexer/WEBSOCKET_API.md
+++ b/docs/indexer/WEBSOCKET_API.md
@@ -1,0 +1,153 @@
+# Linkora Indexer WebSocket API
+
+The indexer exposes a real-time WebSocket stream of contract events. Downstream
+systems (web/mobile clients, search indexers, notification services) subscribe
+here instead of polling the database.
+
+**Endpoint:** `ws://<host>:<PORT>/ws` (default port `3000`)
+
+Events are published to the stream **only after** they have been durably
+committed by the exactly-once ingestion pipeline, so every frame a client
+receives corresponds to a persisted event.
+
+---
+
+## Connection lifecycle
+
+1. Client opens a WebSocket to `/ws`.
+2. By default the client receives **all** event types. To narrow the stream,
+   send a `subscribe` control frame (see below).
+3. The server sends a protocol-level **ping every 15 seconds**; clients MUST
+   reply with a pong (browsers and the `ws` library do this automatically). A
+   client that misses a heartbeat is terminated.
+4. On shutdown the server sends WebSocket close code `1001` ("going away").
+
+---
+
+## Server → client frames
+
+Every application frame is a JSON object with a `type` and a `payload`:
+
+```json
+{
+  "type": "<frame type>",
+  "payload": { ... }
+}
+```
+
+### Event frame
+
+Emitted for each committed contract event. `type` is the contract event type
+(`topic[0]`).
+
+```json
+{
+  "type": "PostCreated",
+  "payload": {
+    "type": "PostCreated",
+    "ledgerSequence": 1234567,
+    "eventIndex": 0,
+    "contractId": "CCONTRACT...",
+    "topic": ["PostCreated", "..."],
+    "data": {
+      "id": "0001234567-0000000000",
+      "value": "<base64/raw event value>",
+      "txHash": "<tx hash>",
+      "ledgerClosedAt": "2026-06-22T12:00:00Z",
+      "pagingToken": "0001234567-0000000000"
+    }
+  }
+}
+```
+
+| Field                    | Type       | Description                                          |
+| ------------------------ | ---------- | ---------------------------------------------------- |
+| `payload.type`           | `string`   | Contract event type (same as the frame `type`).      |
+| `payload.ledgerSequence` | `number`   | Ledger the event was emitted in.                     |
+| `payload.eventIndex`     | `number`   | Index of the event within its ledger.                |
+| `payload.contractId`     | `string`   | Contract that emitted the event.                     |
+| `payload.topic`          | `string[]` | Raw event topic array.                               |
+| `payload.data`           | `object`   | Event body (decoded/raw fields).                     |
+
+The pair `(ledgerSequence, eventIndex)` uniquely identifies an event and can be
+used by clients to deduplicate if they reconnect.
+
+### Subscription acknowledgement
+
+Sent in response to a successful `subscribe` control frame.
+
+```json
+{ "type": "subscribed", "payload": { "types": ["PostCreated", "Follow"] } }
+```
+
+`["*"]` indicates the client is subscribed to all event types.
+
+### Error frame
+
+Sent when a client control frame is malformed.
+
+```json
+{ "type": "error", "payload": { "message": "subscribe requires a string[] 'types' field" } }
+```
+
+---
+
+## Client → server frames
+
+### `subscribe`
+
+Narrow the set of event types delivered to this connection. Replaces any
+previous subscription for the connection.
+
+```json
+{ "action": "subscribe", "types": ["PostCreated", "Follow"] }
+```
+
+| Field    | Type       | Description                                                            |
+| -------- | ---------- | --------------------------------------------------------------------- |
+| `action` | `string`   | Must be `"subscribe"`.                                                 |
+| `types`  | `string[]` | Event types to receive. Empty array or `["*"]` subscribes to all.     |
+
+Unknown actions, non-JSON frames, or an invalid `types` field produce an
+`error` frame; the connection stays open.
+
+---
+
+## Event types
+
+Event types correspond to contract events. Current types include:
+
+| Type             | Description                          |
+| ---------------- | ------------------------------------ |
+| `PostCreated`    | A post was created.                  |
+| `PostDeleted`    | A post was soft-deleted.             |
+| `Follow`         | A follow edge was created.           |
+| `Unfollow`       | A follow edge was removed.           |
+| `ProfileSet`     | A profile was created/updated.       |
+| `Tip`            | A post was tipped.                   |
+| `LikePost`       | A post was liked.                    |
+| `PoolCreated`    | A pool was created.                  |
+| `PoolDeposit`    | A deposit was made to a pool.        |
+| `PoolWithdraw`   | A withdrawal was made from a pool.   |
+
+`*` is a reserved meta-type meaning "all events" and is only valid in
+`subscribe` frames — it is never used as the `type` of an event frame.
+
+---
+
+## Example (browser)
+
+```js
+const ws = new WebSocket("ws://localhost:3000/ws");
+
+ws.onopen = () => {
+  ws.send(JSON.stringify({ action: "subscribe", types: ["PostCreated", "Tip"] }));
+};
+
+ws.onmessage = (e) => {
+  const { type, payload } = JSON.parse(e.data);
+  if (type === "PostCreated") {
+    console.log("new post in ledger", payload.ledgerSequence, payload.data);
+  }
+};
+```

--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -11,5 +11,10 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 START_LEDGER=0
 
-# Indexer API
+# Indexer API / WebSocket
 PORT=3000
+
+# Backpressure & adaptive polling (optional — defaults shown)
+RPC_RATE_LIMIT_PER_SEC=10
+MIN_POLL_INTERVAL_MS=100
+MAX_POLL_INTERVAL_MS=5000

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -6,9 +6,50 @@ Event indexer for the Linkora Social contract on Stellar. Processes on-chain eve
 
 The indexer listens to Stellar contract events and processes them into a PostgreSQL database:
 
+```
+RPC getEvents → stream (rate-limited, adaptive, gap-aware)
+              → IngestPipeline (raw_events + domain write + cursor, one txn)
+              → EventBus → WebSocket fanout (/ws)
+```
+
 - **Event Handlers**: Process specific event types (PostCreated, TipEvent, LikeEvent, etc.)
 - **Database**: PostgreSQL with migrations for schema management
 - **Idempotency**: All handlers are idempotent using unique constraints and transaction hashes
+
+### Exactly-once ingestion
+
+Each batch is ingested inside a **single serialisable transaction**:
+
+1. Events are staged into `raw_events` (`ON CONFLICT (ledger_sequence, event_index) DO NOTHING`).
+2. They are projected into the domain tables (posts, follows, …) via the same transaction client.
+3. `indexer_state.processed_cursor` is advanced — the **last** statement before `COMMIT`.
+
+Because the raw ingest, domain write, and cursor advance commit atomically, a crash
+mid-batch rolls everything back. On restart the batch is replayed and the `ON CONFLICT`
+clause plus idempotent handlers guarantee **no duplicate domain rows**. See
+[`src/pipeline.ts`](src/pipeline.ts).
+
+### Backpressure & adaptive polling
+
+- A **token-bucket rate limiter** caps outbound RPC calls (default 10 req/s,
+  `RPC_RATE_LIMIT_PER_SEC`). See [`src/ratelimit.ts`](src/ratelimit.ts).
+- The **poll interval adapts** to load: it doubles (up to 5s) when a batch is empty
+  and halves (down to 100ms) on a full page. See [`src/poller.ts`](src/poller.ts).
+- `429` responses trigger **exponential backoff with retries**; the window is
+  re-fetched so no events are dropped.
+
+### Pub/sub fanout
+
+An in-process [`EventBus`](src/bus.ts) (Node `EventEmitter`) lets downstream consumers
+subscribe to typed event channels instead of polling the DB. The WebSocket handler
+(`/ws`) is the first consumer — see [`docs/indexer/WEBSOCKET_API.md`](../../docs/indexer/WEBSOCKET_API.md).
+
+### Gap detection
+
+After each batch the first event's ledger is compared to `cursor + 1`. A jump (e.g. from
+RPC node failover mid-sequence) emits a structured `gap_detected` log and triggers a
+**targeted backfill** of the missing range before the batch is processed. See
+[`src/gap.ts`](src/gap.ts).
 
 ## Event Handlers
 
@@ -114,7 +155,10 @@ See [`.env.example`](.env.example) for all required variables.
 | `STELLAR_RPC_URL` | Soroban RPC endpoint |
 | `CONTRACT_ID` | Deployed Linkora contract address |
 | `START_LEDGER` | Ledger sequence to start indexing from |
-| `PORT` | API port (default: `3000`) |
+| `PORT` | HTTP/WS port (default: `3000`) |
+| `RPC_RATE_LIMIT_PER_SEC` | Token-bucket RPC rate cap (default: `10`) |
+| `MIN_POLL_INTERVAL_MS` | Adaptive poll floor (default: `100`) |
+| `MAX_POLL_INTERVAL_MS` | Adaptive poll ceiling (default: `5000`) |
 
 ## Manual Setup
 
@@ -135,8 +179,10 @@ npm install
 # Apply migrations manually
 psql "$DATABASE_URL" -f migrations/001_profiles.sql
 psql "$DATABASE_URL" -f migrations/002_posts.sql
+psql "$DATABASE_URL" -f migrations/003_follows.sql
 psql "$DATABASE_URL" -f migrations/004_tips_likes.sql
 psql "$DATABASE_URL" -f migrations/005_pools.sql
+psql "$DATABASE_URL" -f migrations/006_raw_events.sql
 ```
 
 ### Configuration

--- a/services/indexer/migrations/006_raw_events.sql
+++ b/services/indexer/migrations/006_raw_events.sql
@@ -1,0 +1,36 @@
+-- Migration: Create raw_events staging table and indexer_state cursor
+-- Description: Backbone of the exactly-once ingestion pipeline.
+--
+-- Events are first written to `raw_events` (idempotent on the natural
+-- (ledger_sequence, event_index) key), then projected into the domain
+-- tables (posts, follows, …) inside the SAME serialisable transaction.
+-- `indexer_state.processed_cursor` only advances when that transaction
+-- commits, so a crash mid-batch rolls back the raw ingest, the domain
+-- write, AND the cursor together — guaranteeing no duplicate domain rows
+-- on restart.
+
+CREATE TABLE IF NOT EXISTS raw_events (
+    id              BIGSERIAL   NOT NULL,
+    ledger_sequence BIGINT      NOT NULL,
+    event_index     INT         NOT NULL,
+    contract_id     TEXT        NOT NULL,
+    topic           TEXT[]      NOT NULL,
+    data            JSONB       NOT NULL,
+    processed_at    TIMESTAMPTZ,
+    PRIMARY KEY (ledger_sequence, event_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_events_id          ON raw_events (id);
+CREATE INDEX IF NOT EXISTS idx_raw_events_contract_id ON raw_events (contract_id);
+CREATE INDEX IF NOT EXISTS idx_raw_events_ledger      ON raw_events (ledger_sequence);
+
+-- Single-row-per-stream cursor table. `id` identifies the stream (we use the
+-- contract id, or 'default' for a single-contract deployment).
+CREATE TABLE IF NOT EXISTS indexer_state (
+    id               TEXT        PRIMARY KEY,
+    -- Last ledger sequence whose DOMAIN write has committed. Advancing this
+    -- is the final statement of the ingest transaction; never bump it after
+    -- the raw ingest alone.
+    processed_cursor BIGINT      NOT NULL DEFAULT 0,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/indexer/package.json
+++ b/services/indexer/package.json
@@ -15,13 +15,15 @@
   "dependencies": {
     "express": "^4.19.2",
     "express-rate-limit": "^7.3.1",
-    "pg": "^8.12.0"
+    "pg": "^8.12.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
     "@types/pg": "^8.11.6",
+    "@types/ws": "^8.5.10",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.8.3"

--- a/services/indexer/src/__tests__/bus.test.ts
+++ b/services/indexer/src/__tests__/bus.test.ts
@@ -1,0 +1,71 @@
+/**
+ * In-process event bus tests.
+ */
+
+import { EventBus, BusEvent } from "../bus";
+
+function evt(type: string, ledger: number): BusEvent {
+  return {
+    type,
+    ledgerSequence: ledger,
+    eventIndex: 0,
+    contractId: "C1",
+    topic: [type],
+    data: {},
+  };
+}
+
+describe("EventBus", () => {
+  it("delivers events to type-specific subscribers", () => {
+    const bus = new EventBus();
+    const got: number[] = [];
+    bus.on("PostCreated", (e) => got.push(e.ledgerSequence));
+
+    bus.publish(evt("PostCreated", 1));
+    bus.publish(evt("Follow", 2)); // different channel
+    bus.publish(evt("PostCreated", 3));
+
+    expect(got).toEqual([1, 3]);
+  });
+
+  it("delivers every event to wildcard subscribers", () => {
+    const bus = new EventBus();
+    const got: string[] = [];
+    bus.onAny((e) => got.push(e.type));
+
+    bus.publish(evt("PostCreated", 1));
+    bus.publish(evt("Follow", 2));
+
+    expect(got).toEqual(["PostCreated", "Follow"]);
+  });
+
+  it("unsubscribe stops further delivery", () => {
+    const bus = new EventBus();
+    const got: number[] = [];
+    const off = bus.on("Tip", (e) => got.push(e.ledgerSequence));
+
+    bus.publish(evt("Tip", 1));
+    off();
+    bus.publish(evt("Tip", 2));
+
+    expect(got).toEqual([1]);
+  });
+
+  it("isolates listener exceptions so fanout continues", () => {
+    const bus = new EventBus();
+    const got: string[] = [];
+    bus.onAny(() => {
+      throw new Error("bad consumer");
+    });
+    bus.onAny((e) => got.push(e.type));
+
+    expect(() => bus.publish(evt("PostCreated", 1))).not.toThrow();
+    expect(got).toEqual(["PostCreated"]);
+  });
+
+  it("supports many subscribers without a max-listener warning", () => {
+    const bus = new EventBus();
+    for (let i = 0; i < 50; i++) bus.onAny(() => undefined);
+    expect(bus.listenerCount("*")).toBe(50);
+  });
+});

--- a/services/indexer/src/__tests__/gap.test.ts
+++ b/services/indexer/src/__tests__/gap.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Mid-stream ledger gap detection tests.
+ */
+
+import { detectGap } from "../gap";
+
+describe("detectGap", () => {
+  it("reports no gap when the batch continues the sequence", () => {
+    expect(detectGap(101, 100)).toEqual({ hasGap: false });
+  });
+
+  it("reports a gap when the batch skips ahead (RPC failover)", () => {
+    // cursor=100, expected 101, but the batch starts at 105 → 101..104 missing.
+    expect(detectGap(105, 100)).toEqual({
+      hasGap: true,
+      fromLedger: 101,
+      toLedger: 104,
+    });
+  });
+
+  it("treats a single skipped ledger as a one-ledger gap", () => {
+    expect(detectGap(103, 101)).toEqual({
+      hasGap: true,
+      fromLedger: 102,
+      toLedger: 102,
+    });
+  });
+
+  it("reports no gap on re-delivery / overlap", () => {
+    expect(detectGap(98, 100)).toEqual({ hasGap: false });
+    expect(detectGap(100, 100)).toEqual({ hasGap: false });
+  });
+
+  it("reports no gap on an empty batch", () => {
+    expect(detectGap(undefined, 100)).toEqual({ hasGap: false });
+  });
+
+  it("reports no gap before the first batch (cursor 0)", () => {
+    expect(detectGap(500000, 0)).toEqual({ hasGap: false });
+  });
+});

--- a/services/indexer/src/__tests__/pipeline.test.ts
+++ b/services/indexer/src/__tests__/pipeline.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Exactly-once pipeline tests.
+ *
+ * Uses an in-memory fake of pg's Pool/Client that enforces:
+ *   - PRIMARY KEY (ledger_sequence, event_index) with ON CONFLICT DO NOTHING
+ *   - real transaction isolation (writes are staged in an overlay and only
+ *     merged into the committed store on COMMIT; discarded on ROLLBACK)
+ *
+ * That lets us reproduce a crash *between* the raw ingest and the domain write
+ * and prove that no duplicate domain rows survive on restart.
+ */
+
+import { EventBus } from "../bus";
+import {
+  IngestPipeline,
+  IngestEvent,
+  DomainProcessor,
+  PgClientLike,
+  PgPoolLike,
+  QueryResultLike,
+} from "../pipeline";
+
+type Store = {
+  raw: Map<string, IngestEvent>;
+  posts: Map<string, { id: string; author: string }>;
+  cursor: Map<string, number>;
+};
+
+function emptyStore(): Store {
+  return { raw: new Map(), posts: new Map(), cursor: new Map() };
+}
+
+function cloneStore(s: Store): Store {
+  return {
+    raw: new Map(s.raw),
+    posts: new Map(s.posts),
+    cursor: new Map(s.cursor),
+  };
+}
+
+class FakeClient implements PgClientLike {
+  private overlay: Store | null = null;
+
+  constructor(private readonly committed: { value: Store }) {}
+
+  private active(): Store {
+    return this.overlay ?? this.committed.value;
+  }
+
+  async query(text: string, params: unknown[] = []): Promise<QueryResultLike> {
+    const sql = text.trim();
+
+    if (sql.startsWith("BEGIN")) {
+      this.overlay = cloneStore(this.committed.value);
+      return { rowCount: 0, rows: [] };
+    }
+    if (sql.startsWith("COMMIT")) {
+      if (this.overlay) this.committed.value = this.overlay;
+      this.overlay = null;
+      return { rowCount: 0, rows: [] };
+    }
+    if (sql.startsWith("ROLLBACK")) {
+      this.overlay = null;
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (sql.startsWith("INSERT INTO raw_events")) {
+      const key = `${params[0]}-${params[1]}`;
+      const store = this.active();
+      if (store.raw.has(key)) return { rowCount: 0, rows: [] }; // ON CONFLICT DO NOTHING
+      store.raw.set(key, {
+        ledgerSequence: Number(params[0]),
+        eventIndex: Number(params[1]),
+        contractId: String(params[2]),
+        topic: params[3] as string[],
+        type: (params[3] as string[])[0] ?? "unknown",
+        data: params[4],
+      });
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (sql.startsWith("INSERT INTO posts")) {
+      const id = String(params[0]);
+      const store = this.active();
+      if (store.posts.has(id)) return { rowCount: 0, rows: [] }; // ON CONFLICT DO NOTHING
+      store.posts.set(id, { id, author: String(params[1]) });
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (sql.startsWith("UPDATE raw_events SET processed_at")) {
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (sql.startsWith("INSERT INTO indexer_state")) {
+      const store = this.active();
+      const streamId = String(params[0]);
+      const next = Number(params[1]);
+      const prev = store.cursor.get(streamId) ?? 0;
+      store.cursor.set(streamId, Math.max(prev, next)); // GREATEST(...)
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (sql.startsWith("SELECT processed_cursor FROM indexer_state")) {
+      const streamId = String(params[0]);
+      const value = this.active().cursor.get(streamId);
+      return {
+        rowCount: value === undefined ? 0 : 1,
+        rows: value === undefined ? [] : [{ processed_cursor: value }],
+      };
+    }
+
+    throw new Error(`FakeClient: unhandled SQL: ${sql}`);
+  }
+
+  release(): void {
+    /* no-op */
+  }
+}
+
+class FakePool implements PgPoolLike {
+  readonly committed = { value: emptyStore() };
+  async connect(): Promise<PgClientLike> {
+    return new FakeClient(this.committed);
+  }
+}
+
+function makeEvent(ledger: number, index: number, author: string): IngestEvent {
+  return {
+    ledgerSequence: ledger,
+    eventIndex: index,
+    contractId: "C123",
+    type: "PostCreated",
+    topic: ["PostCreated"],
+    data: { author },
+  };
+}
+
+// A domain processor that projects PostCreated into the posts table, with an
+// optional one-shot "crash" injected between the raw ingest and this write.
+function postProcessor(crashOnce: { value: boolean }): DomainProcessor {
+  return async (client, event) => {
+    if (crashOnce.value) {
+      crashOnce.value = false;
+      throw new Error("simulated crash before domain write");
+    }
+    const author = (event.data as { author: string }).author;
+    await client.query(
+      `INSERT INTO posts (id, author) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+      [`${event.ledgerSequence}:${event.eventIndex}`, author]
+    );
+  };
+}
+
+describe("IngestPipeline — exactly-once", () => {
+  it("commits raw + domain + cursor atomically", async () => {
+    const pool = new FakePool();
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: new EventBus(),
+      domainProcessor: postProcessor({ value: false }),
+    });
+
+    const res = await pipeline.processBatch([makeEvent(10, 0, "alice")]);
+
+    expect(res.committed).toBe(true);
+    expect(res.cursor).toBe(10);
+    expect(pool.committed.value.raw.size).toBe(1);
+    expect(pool.committed.value.posts.size).toBe(1);
+    expect(pool.committed.value.cursor.get("C123")).toBe(10);
+  });
+
+  it("rolls back the raw ingest when the domain write crashes", async () => {
+    const pool = new FakePool();
+    const crash = { value: true };
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: new EventBus(),
+      domainProcessor: postProcessor(crash),
+    });
+
+    await expect(pipeline.processBatch([makeEvent(10, 0, "alice")])).rejects.toThrow(
+      /simulated crash/
+    );
+
+    // Nothing persisted: raw, domain, and cursor all rolled back together.
+    expect(pool.committed.value.raw.size).toBe(0);
+    expect(pool.committed.value.posts.size).toBe(0);
+    expect(pool.committed.value.cursor.get("C123")).toBeUndefined();
+  });
+
+  it("produces no duplicate domain rows on restart after a crash", async () => {
+    const pool = new FakePool();
+    const crash = { value: true };
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: new EventBus(),
+      domainProcessor: postProcessor(crash),
+    });
+
+    const batch = [makeEvent(10, 0, "alice"), makeEvent(10, 1, "bob")];
+
+    // First attempt crashes mid-batch and rolls back entirely.
+    await expect(pipeline.processBatch(batch)).rejects.toThrow();
+    expect(pool.committed.value.posts.size).toBe(0);
+
+    // Restart: replay the same batch — succeeds this time.
+    const res = await pipeline.processBatch(batch);
+    expect(res.committed).toBe(true);
+
+    // Exactly two posts, two raw rows — no duplicates despite the replay.
+    expect(pool.committed.value.posts.size).toBe(2);
+    expect(pool.committed.value.raw.size).toBe(2);
+    expect(pool.committed.value.cursor.get("C123")).toBe(10);
+  });
+
+  it("is idempotent when the identical batch is replayed after commit", async () => {
+    const pool = new FakePool();
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: new EventBus(),
+      domainProcessor: postProcessor({ value: false }),
+    });
+
+    const batch = [makeEvent(20, 0, "carol")];
+    await pipeline.processBatch(batch);
+    const second = await pipeline.processBatch(batch); // duplicate delivery
+
+    expect(second.inserted).toBe(0); // raw ON CONFLICT skipped
+    expect(pool.committed.value.posts.size).toBe(1);
+    expect(pool.committed.value.raw.size).toBe(1);
+  });
+
+  it("publishes to the bus only after commit", async () => {
+    const pool = new FakePool();
+    const busInstance = new EventBus();
+    const received: number[] = [];
+    busInstance.onAny((e) => received.push(e.ledgerSequence));
+
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: busInstance,
+      domainProcessor: postProcessor({ value: true }), // crash first
+    });
+
+    const batch = [makeEvent(30, 0, "dave")];
+    await expect(pipeline.processBatch(batch)).rejects.toThrow();
+    expect(received).toEqual([]); // nothing published on rollback
+
+    await pipeline.processBatch(batch);
+    expect(received).toEqual([30]); // published exactly once, after commit
+  });
+
+  it("readCursor reflects the last committed cursor", async () => {
+    const pool = new FakePool();
+    const pipeline = new IngestPipeline(pool, {
+      streamId: "C123",
+      bus: new EventBus(),
+      domainProcessor: postProcessor({ value: false }),
+    });
+
+    expect(await pipeline.readCursor()).toBe(0);
+    await pipeline.processBatch([makeEvent(42, 0, "erin")]);
+    expect(await pipeline.readCursor()).toBe(42);
+  });
+});

--- a/services/indexer/src/__tests__/poller.test.ts
+++ b/services/indexer/src/__tests__/poller.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Adaptive poll-interval tests.
+ */
+
+import { AdaptivePoll } from "../poller";
+
+describe("AdaptivePoll", () => {
+  it("doubles the interval on an empty batch, capped at maxMs", () => {
+    const poll = new AdaptivePoll({ minMs: 100, maxMs: 5000, pageSize: 100, startMs: 1000 });
+    expect(poll.next(0)).toBe(2000);
+    expect(poll.next(0)).toBe(4000);
+    expect(poll.next(0)).toBe(5000); // capped
+    expect(poll.next(0)).toBe(5000);
+  });
+
+  it("halves the interval on a full page, floored at minMs", () => {
+    const poll = new AdaptivePoll({ minMs: 100, maxMs: 5000, pageSize: 100, startMs: 800 });
+    expect(poll.next(100)).toBe(400);
+    expect(poll.next(100)).toBe(200);
+    expect(poll.next(100)).toBe(100); // floored
+    expect(poll.next(100)).toBe(100);
+  });
+
+  it("holds steady on a partial batch", () => {
+    const poll = new AdaptivePoll({ minMs: 100, maxMs: 5000, pageSize: 100, startMs: 1000 });
+    expect(poll.next(50)).toBe(1000);
+    expect(poll.next(1)).toBe(1000);
+    expect(poll.next(99)).toBe(1000);
+  });
+
+  it("defaults to starting at maxMs (slow start)", () => {
+    const poll = new AdaptivePoll({ pageSize: 100 });
+    expect(poll.intervalMs).toBe(5000);
+    expect(poll.minMs).toBe(100);
+    expect(poll.maxMs).toBe(5000);
+  });
+
+  it("reacts to changing load: speeds up then backs off", () => {
+    const poll = new AdaptivePoll({ minMs: 100, maxMs: 5000, pageSize: 100, startMs: 5000 });
+    // Burst of full pages drives it down toward the floor.
+    poll.next(100);
+    poll.next(100);
+    poll.next(100);
+    poll.next(100);
+    poll.next(100);
+    poll.next(100);
+    expect(poll.intervalMs).toBe(100);
+    // Then it goes idle and backs off again.
+    expect(poll.next(0)).toBe(200);
+  });
+});

--- a/services/indexer/src/__tests__/ratelimit.test.ts
+++ b/services/indexer/src/__tests__/ratelimit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Token-bucket rate limiter tests, driven by a fake clock so behaviour is
+ * deterministic and instant.
+ */
+
+import { TokenBucket } from "../ratelimit";
+
+/** Controllable clock + sleep where sleeping advances the clock. */
+function fakeTime() {
+  let now = 0;
+  return {
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+describe("TokenBucket", () => {
+  it("allows up to `burst` immediate requests, then throttles", () => {
+    const t = fakeTime();
+    const bucket = new TokenBucket({ ratePerSec: 10, burst: 3, now: t.now, sleep: t.sleep });
+
+    expect(bucket.tryRemove()).toBe(true);
+    expect(bucket.tryRemove()).toBe(true);
+    expect(bucket.tryRemove()).toBe(true);
+    expect(bucket.tryRemove()).toBe(false); // bucket drained
+  });
+
+  it("refills continuously at the configured rate", () => {
+    const t = fakeTime();
+    const bucket = new TokenBucket({ ratePerSec: 10, burst: 1, now: t.now, sleep: t.sleep });
+
+    expect(bucket.tryRemove()).toBe(true);
+    expect(bucket.tryRemove()).toBe(false);
+
+    t.advance(100); // 10 req/s → one token per 100ms
+    expect(bucket.tryRemove()).toBe(true);
+  });
+
+  it("acquire() waits for the next token instead of failing", async () => {
+    const t = fakeTime();
+    const bucket = new TokenBucket({ ratePerSec: 10, burst: 1, now: t.now, sleep: t.sleep });
+
+    await bucket.acquire(); // consumes the initial token at t=0
+    await bucket.acquire(); // must wait ~100ms for a refill
+
+    expect(t.now()).toBeGreaterThanOrEqual(100);
+  });
+
+  it("never issues more than burst + rate*elapsed tokens", async () => {
+    const t = fakeTime();
+    const rate = 10;
+    const burst = 1;
+    const bucket = new TokenBucket({ ratePerSec: rate, burst, now: t.now, sleep: t.sleep });
+
+    const n = 20;
+    for (let i = 0; i < n; i++) {
+      await bucket.acquire();
+    }
+    // Token-bucket invariant: tokens issued ≤ burst + rate * elapsed. The first
+    // `burst` tokens are free; the rest are paced at `rate`, so n tokens take
+    // (n - burst)/rate seconds.
+    const elapsedSec = t.now() / 1000;
+    expect(n).toBeLessThanOrEqual(burst + rate * elapsedSec + 0.001);
+    expect(elapsedSec).toBeCloseTo((n - burst) / rate, 5);
+  });
+
+  it("reports msUntilNextToken when empty", () => {
+    const t = fakeTime();
+    const bucket = new TokenBucket({ ratePerSec: 5, burst: 1, now: t.now, sleep: t.sleep });
+    bucket.tryRemove();
+    expect(bucket.msUntilNextToken()).toBe(200); // 5 req/s → 200ms per token
+  });
+
+  it("rejects an invalid rate", () => {
+    expect(() => new TokenBucket({ ratePerSec: 0 })).toThrow();
+  });
+});

--- a/services/indexer/src/__tests__/stream.test.ts
+++ b/services/indexer/src/__tests__/stream.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Stream backpressure / 429 resilience tests.
+ *
+ * Drives streamEvents with an injected fetch, sleep, and rate limiter so the
+ * loop runs instantly and deterministically. Verifies that 429 responses cause
+ * exponential backoff and that no events are dropped.
+ */
+
+import { streamEvents, RawEvent, parseEventIndex, RpcError } from "../stream";
+import { TokenBucket } from "../ratelimit";
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+}
+
+function rpcResult(events: Array<Partial<RawEvent>>, latestLedger: number): FakeResponse {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ result: { events, latestLedger } }),
+  };
+}
+
+function rpc429(): FakeResponse {
+  return {
+    ok: false,
+    status: 429,
+    statusText: "Too Many Requests",
+    json: async () => ({}),
+  };
+}
+
+function makeRawEvents(ledger: number, count: number): Array<Partial<RawEvent>> {
+  return Array.from({ length: count }, (_, i) => ({
+    type: "contract",
+    ledger,
+    ledgerClosedAt: "2026-06-22T00:00:00Z",
+    contractId: "C1",
+    id: `00000000${ledger}-000000000${i}`,
+    pagingToken: `tok-${ledger}-${i}`,
+    topic: ["PostCreated"],
+    value: "v",
+    txHash: `tx-${i}`,
+  }));
+}
+
+/** A rate limiter that never blocks (fast clock + instant sleep). */
+function nonBlockingLimiter(): TokenBucket {
+  return new TokenBucket({ ratePerSec: 1e6, burst: 1e6, now: () => 0, sleep: async () => {} });
+}
+
+describe("parseEventIndex", () => {
+  it("parses the index suffix from a Soroban event id", () => {
+    expect(parseEventIndex("0004023007-0000000003", 9)).toBe(3);
+  });
+  it("falls back to the ordinal for a malformed id", () => {
+    expect(parseEventIndex("no-dash-here-xyz", 7)).toBe(7);
+    expect(parseEventIndex("", 4)).toBe(4);
+  });
+});
+
+describe("streamEvents — 429 backpressure", () => {
+  it("backs off exponentially on 429 and drops no events", async () => {
+    const controller = new AbortController();
+    const backoffs: number[] = [];
+    const sleep = async (ms: number) => {
+      backoffs.push(ms);
+    };
+
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      // Three consecutive 429s, then a partial page of 3 events.
+      if (call <= 3) return rpc429() as unknown as Response;
+      if (call === 4) return rpcResult(makeRawEvents(10, 3), 10) as unknown as Response;
+      return rpcResult([], 10) as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const processed: RawEvent[] = [];
+    const process = async (events: RawEvent[]): Promise<number> => {
+      processed.push(...events);
+      controller.abort(); // stop after the first real batch
+      return events[events.length - 1].ledger;
+    };
+
+    await streamEvents(
+      {
+        rpcUrl: "http://rpc",
+        contractId: "C1",
+        startLedger: 10,
+        backoffBaseMs: 100,
+        maxRetries: 6,
+        minPollMs: 1,
+        maxPollMs: 5,
+      },
+      process,
+      controller.signal,
+      { fetchImpl, sleep, rateLimiter: nonBlockingLimiter() }
+    );
+
+    // Exponential backoff: 100, 200, 400 for the three 429s.
+    expect(backoffs).toEqual([100, 200, 400]);
+
+    // All three events delivered exactly once — nothing dropped.
+    expect(processed).toHaveLength(3);
+    expect(processed.map((e) => e.eventIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("gives up after maxRetries and surfaces the error without crashing the loop", async () => {
+    const controller = new AbortController();
+    const sleep = async () => {};
+
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      if (call <= 2) return rpc429() as unknown as Response;
+      // After the exhausted-retry error is logged, the loop retries the window
+      // and we let it succeed so we can abort cleanly.
+      return rpcResult(makeRawEvents(10, 1), 10) as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const process = async (events: RawEvent[]): Promise<number> => {
+      controller.abort();
+      return events[events.length - 1].ledger;
+    };
+
+    await expect(
+      streamEvents(
+        {
+          rpcUrl: "http://rpc",
+          contractId: "C1",
+          startLedger: 10,
+          backoffBaseMs: 1,
+          maxRetries: 1, // exhausted after the 2nd 429
+          minPollMs: 1,
+          maxPollMs: 2,
+        },
+        process,
+        controller.signal,
+        { fetchImpl, sleep, rateLimiter: nonBlockingLimiter() }
+      )
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("RpcError", () => {
+  it("carries the HTTP status", () => {
+    const err = new RpcError("boom", 429);
+    expect(err.status).toBe(429);
+    expect(err.name).toBe("RpcError");
+  });
+});

--- a/services/indexer/src/__tests__/ws.test.ts
+++ b/services/indexer/src/__tests__/ws.test.ts
@@ -1,0 +1,184 @@
+/**
+ * WebSocket fanout tests.
+ *
+ * Spins up a real HTTP+WS server on an ephemeral port, connects real `ws`
+ * clients, and asserts events flow from the bus to clients within the 200ms
+ * SLA — including under a synthetic burst.
+ */
+
+import http from "http";
+import { AddressInfo } from "net";
+import WebSocket from "ws";
+import { EventBus, BusEvent } from "../bus";
+import { attachWebSocketServer, WsHandle } from "../ws";
+
+function busEvent(type: string, ledger: number, index = 0): BusEvent {
+  return {
+    type,
+    ledgerSequence: ledger,
+    eventIndex: index,
+    contractId: "C1",
+    topic: [type],
+    data: { n: ledger },
+  };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+interface Harness {
+  server: http.Server;
+  handle: WsHandle;
+  bus: EventBus;
+  port: number;
+}
+
+async function startHarness(heartbeatMs = 15_000): Promise<Harness> {
+  const bus = new EventBus();
+  const server = http.createServer();
+  const handle = attachWebSocketServer(server, bus, { path: "/ws", heartbeatMs });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+  return { server, handle, bus, port };
+}
+
+async function stopHarness(h: Harness): Promise<void> {
+  await h.handle.close();
+  await new Promise<void>((resolve) => h.server.close(() => resolve()));
+}
+
+function connect(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://localhost:${port}/ws`);
+  return new Promise((resolve, reject) => {
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+}
+
+describe("WebSocket fanout", () => {
+  let h: Harness;
+
+  afterEach(async () => {
+    if (h) await stopHarness(h);
+  });
+
+  it("pushes an event to a connected client within 200ms", async () => {
+    h = await startHarness();
+    const client = await connect(h.port);
+    await waitFor(() => h.handle.clientCount() === 1);
+
+    const received = new Promise<{ frame: any; at: number }>((resolve) => {
+      client.on("message", (data) =>
+        resolve({ frame: JSON.parse(data.toString()), at: Date.now() })
+      );
+    });
+
+    const sentAt = Date.now();
+    h.bus.publish(busEvent("PostCreated", 100));
+
+    const { frame, at } = await received;
+    expect(at - sentAt).toBeLessThan(200);
+    expect(frame.type).toBe("PostCreated");
+    expect(frame.payload.ledgerSequence).toBe(100);
+
+    client.close();
+  });
+
+  it("delivers a synthetic burst to all clients within 200ms each", async () => {
+    h = await startHarness();
+    const clientA = await connect(h.port);
+    const clientB = await connect(h.port);
+    await waitFor(() => h.handle.clientCount() === 2);
+
+    const N = 100;
+    const collect = (ws: WebSocket): Promise<number[]> =>
+      new Promise((resolve) => {
+        const latencies: number[] = [];
+        ws.on("message", (data) => {
+          const frame = JSON.parse(data.toString());
+          latencies.push(Date.now() - frame.payload.data.sentAt);
+          if (latencies.length === N) resolve(latencies);
+        });
+      });
+
+    const a = collect(clientA);
+    const b = collect(clientB);
+
+    for (let i = 0; i < N; i++) {
+      const sentAt = Date.now();
+      h.bus.publish({
+        type: "Tip",
+        ledgerSequence: i,
+        eventIndex: 0,
+        contractId: "C1",
+        topic: ["Tip"],
+        data: { sentAt },
+      });
+    }
+
+    const [latA, latB] = await Promise.all([a, b]);
+    expect(latA).toHaveLength(N);
+    expect(latB).toHaveLength(N);
+    expect(Math.max(...latA, ...latB)).toBeLessThan(200);
+
+    clientA.close();
+    clientB.close();
+  });
+
+  it("honours type subscriptions", async () => {
+    h = await startHarness();
+    const client = await connect(h.port);
+    await waitFor(() => h.handle.clientCount() === 1);
+
+    // Subscribe to only "Follow" and wait for the ack.
+    const ack = new Promise<any>((resolve) => {
+      client.on("message", (data) => {
+        const frame = JSON.parse(data.toString());
+        if (frame.type === "subscribed") resolve(frame);
+      });
+    });
+    client.send(JSON.stringify({ action: "subscribe", types: ["Follow"] }));
+    const ackFrame = await ack;
+    expect(ackFrame.payload.types).toEqual(["Follow"]);
+
+    const types: string[] = [];
+    client.removeAllListeners("message");
+    client.on("message", (data) => types.push(JSON.parse(data.toString()).type));
+
+    h.bus.publish(busEvent("PostCreated", 1)); // filtered out
+    h.bus.publish(busEvent("Follow", 2)); // delivered
+
+    await waitFor(() => types.includes("Follow"));
+    expect(types).not.toContain("PostCreated");
+
+    client.close();
+  });
+
+  it("cleans up client state on disconnect", async () => {
+    h = await startHarness();
+    const client = await connect(h.port);
+    await waitFor(() => h.handle.clientCount() === 1);
+
+    client.close();
+    await waitFor(() => h.handle.clientCount() === 0);
+    expect(h.handle.clientCount()).toBe(0);
+  });
+
+  it("keeps a responsive client alive across heartbeats", async () => {
+    h = await startHarness(40); // fast heartbeat
+    const client = await connect(h.port);
+    await waitFor(() => h.handle.clientCount() === 1);
+
+    // `ws` auto-replies to pings with pongs; the client should survive.
+    await new Promise((r) => setTimeout(r, 150)); // several heartbeat cycles
+    expect(h.handle.clientCount()).toBe(1);
+    expect(client.readyState).toBe(WebSocket.OPEN);
+
+    client.close();
+  });
+});

--- a/services/indexer/src/bus.ts
+++ b/services/indexer/src/bus.ts
@@ -1,0 +1,91 @@
+/**
+ * In-process pub/sub event bus.
+ *
+ * Decouples the ingestion pipeline from downstream consumers (the WebSocket
+ * push handler today; a search indexer or notification service tomorrow).
+ * Consumers subscribe to typed channels instead of polling the database.
+ *
+ * Built on Node's EventEmitter. Channels are keyed by contract event type
+ * (the first element of an event's `topic` array, e.g. "PostCreated"),
+ * plus a wildcard `"*"` channel that receives every event.
+ */
+
+import { EventEmitter } from "events";
+
+/**
+ * Normalised event payload published on the bus. This is the shape every
+ * downstream consumer sees, independent of how it was sourced from RPC.
+ */
+export interface BusEvent {
+  /** Contract event type, e.g. "PostCreated" — taken from topic[0]. */
+  type: string;
+  /** Ledger the event was emitted in. */
+  ledgerSequence: number;
+  /** Index of the event within its ledger. */
+  eventIndex: number;
+  /** Contract that emitted the event. */
+  contractId: string;
+  /** Raw topic array. */
+  topic: string[];
+  /** Decoded / raw event body. */
+  data: unknown;
+}
+
+/** Channel that receives every event regardless of type. */
+export const ALL_EVENTS = "*";
+
+export type BusListener = (event: BusEvent) => void;
+
+export class EventBus {
+  private readonly emitter = new EventEmitter();
+
+  constructor() {
+    // Downstream consumers can be numerous (every WS client adds one). Lift
+    // the default 10-listener cap and rely on explicit unsubscribe instead.
+    this.emitter.setMaxListeners(0);
+  }
+
+  /**
+   * Subscribe to a specific event type. Returns an unsubscribe function.
+   */
+  on(type: string, listener: BusListener): () => void {
+    this.emitter.on(type, listener);
+    return () => this.emitter.off(type, listener);
+  }
+
+  /**
+   * Subscribe to every event published on the bus. Returns an unsubscribe
+   * function. Used by the WebSocket fanout, which forwards all events.
+   */
+  onAny(listener: BusListener): () => void {
+    return this.on(ALL_EVENTS, listener);
+  }
+
+  /**
+   * Publish an event. Delivered synchronously to the type-specific channel
+   * and to the wildcard channel. Listener exceptions are isolated so one bad
+   * consumer cannot break fanout to the others.
+   */
+  publish(event: BusEvent): void {
+    this.safeEmit(event.type, event);
+    this.safeEmit(ALL_EVENTS, event);
+  }
+
+  /** Number of listeners on a channel — exposed for tests and metrics. */
+  listenerCount(type: string): number {
+    return this.emitter.listenerCount(type);
+  }
+
+  private safeEmit(channel: string, event: BusEvent): void {
+    for (const listener of this.emitter.listeners(channel) as BusListener[]) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.error(`[bus] listener for "${channel}" threw:`, err);
+      }
+    }
+  }
+}
+
+/** Shared bus instance for the indexer process. */
+export const bus = new EventBus();

--- a/services/indexer/src/gap.ts
+++ b/services/indexer/src/gap.ts
@@ -1,0 +1,50 @@
+/**
+ * Mid-stream ledger gap detection.
+ *
+ * Distinct from startup replay: this catches gaps introduced when an RPC node
+ * fails over mid-sequence and the next batch skips ahead. After each batch we
+ * assert the first event's ledger is exactly `lastCursor + 1`. If it jumped,
+ * the ledgers in between were never seen and must be backfilled before we
+ * advance.
+ */
+
+export interface GapResult {
+  /** True when a gap was detected (batch starts beyond the expected ledger). */
+  hasGap: boolean;
+  /** First missing ledger sequence (inclusive), when hasGap. */
+  fromLedger?: number;
+  /** Last missing ledger sequence (inclusive), when hasGap. */
+  toLedger?: number;
+}
+
+const NO_GAP: GapResult = { hasGap: false };
+
+/**
+ * Detect a gap between the last processed cursor and the first event of a new
+ * batch.
+ *
+ * @param batchFirstLedger ledger_sequence of the first event in the batch
+ * @param lastCursor       last ledger we have fully processed (0 = nothing yet)
+ */
+export function detectGap(
+  batchFirstLedger: number | undefined,
+  lastCursor: number
+): GapResult {
+  // Empty batch: nothing to compare.
+  if (batchFirstLedger === undefined) return NO_GAP;
+
+  // Nothing processed yet — the first batch defines the baseline, so any
+  // start ledger is acceptable (startup replay handles the pre-history).
+  if (lastCursor <= 0) return NO_GAP;
+
+  const expected = lastCursor + 1;
+
+  // In-sequence or overlapping (re-delivery) — no gap.
+  if (batchFirstLedger <= expected) return NO_GAP;
+
+  return {
+    hasGap: true,
+    fromLedger: expected,
+    toLedger: batchFirstLedger - 1,
+  };
+}

--- a/services/indexer/src/index.ts
+++ b/services/indexer/src/index.ts
@@ -1,20 +1,30 @@
 /**
  * Linkora Indexer — entry point.
  *
- * Connects to a Soroban RPC endpoint, streams contract events from the
- * Linkora contract, writes raw events to PostgreSQL, and dispatches each
- * event to the appropriate typed handler.
+ * Connects to a Soroban RPC endpoint and streams Linkora contract events
+ * through an exactly-once pipeline:
+ *
+ *   RPC getEvents → stream (rate-limited, adaptive, gap-aware)
+ *                 → IngestPipeline (raw_events + domain write + cursor, 1 txn)
+ *                 → EventBus → WebSocket fanout (/ws)
  *
  * Environment variables (all required unless noted):
- *   DATABASE_URL      - PostgreSQL connection string
- *   STELLAR_RPC_URL   - Soroban RPC endpoint
- *   CONTRACT_ID       - Bech32 contract address
- *   START_LEDGER      - Ledger sequence to start streaming from
- *   POLL_INTERVAL_MS  - (optional) polling interval in ms, default 5000
+ *   DATABASE_URL            - PostgreSQL connection string
+ *   STELLAR_RPC_URL         - Soroban RPC endpoint
+ *   CONTRACT_ID             - Bech32 contract address
+ *   START_LEDGER            - Ledger sequence to start streaming from
+ *   PORT                    - (optional) HTTP/WS port, default 3000
+ *   RPC_RATE_LIMIT_PER_SEC  - (optional) RPC rate cap, default 10
+ *   MIN_POLL_INTERVAL_MS    - (optional) adaptive poll floor, default 100
+ *   MAX_POLL_INTERVAL_MS    - (optional) adaptive poll ceiling, default 5000
  */
 
+import http from "http";
 import { Pool } from "pg";
-import { streamEvents, RawEvent } from "./stream";
+import { streamEvents, RawEvent, BatchProcessor } from "./stream";
+import { IngestPipeline, IngestEvent } from "./pipeline";
+import { bus } from "./bus";
+import { attachWebSocketServer } from "./ws";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -24,100 +34,145 @@ function requireEnv(name: string): string {
   return value;
 }
 
+function optionalIntEnv(name: string): number | undefined {
+  const v = process.env[name];
+  return v ? parseInt(v, 10) : undefined;
+}
+
 const DATABASE_URL = requireEnv("DATABASE_URL");
 const STELLAR_RPC_URL = requireEnv("STELLAR_RPC_URL");
 const CONTRACT_ID = requireEnv("CONTRACT_ID");
 const START_LEDGER = parseInt(requireEnv("START_LEDGER"), 10);
-const POLL_INTERVAL_MS = process.env["POLL_INTERVAL_MS"]
-  ? parseInt(process.env["POLL_INTERVAL_MS"], 10)
-  : undefined;
+const PORT = parseInt(process.env.PORT ?? "3000", 10);
 
 // ── Database ──────────────────────────────────────────────────────────────────
 
 const pgPool = new Pool({ connectionString: DATABASE_URL });
 
-async function ensureEventsTable(): Promise<void> {
+/**
+ * Idempotently ensure the staging table and cursor exist. Mirrors
+ * migrations/006_raw_events.sql for dev/test environments that boot without a
+ * separate migration step.
+ */
+async function ensureSchema(): Promise<void> {
   await pgPool.query(`
-    CREATE TABLE IF NOT EXISTS events (
-      id            BIGSERIAL   PRIMARY KEY,
-      event_id      TEXT        NOT NULL UNIQUE,
-      ledger        INTEGER     NOT NULL,
-      contract_id   TEXT        NOT NULL,
-      topic         TEXT[]      NOT NULL,
-      value         TEXT        NOT NULL,
-      tx_hash       TEXT        NOT NULL,
-      closed_at     TIMESTAMPTZ NOT NULL,
-      indexed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    CREATE TABLE IF NOT EXISTS raw_events (
+      id              BIGSERIAL   NOT NULL,
+      ledger_sequence BIGINT      NOT NULL,
+      event_index     INT         NOT NULL,
+      contract_id     TEXT        NOT NULL,
+      topic           TEXT[]      NOT NULL,
+      data            JSONB       NOT NULL,
+      processed_at    TIMESTAMPTZ,
+      PRIMARY KEY (ledger_sequence, event_index)
     )
   `);
   await pgPool.query(`
-    CREATE INDEX IF NOT EXISTS idx_events_ledger      ON events (ledger);
-    CREATE INDEX IF NOT EXISTS idx_events_contract_id ON events (contract_id);
+    CREATE TABLE IF NOT EXISTS indexer_state (
+      id               TEXT        PRIMARY KEY,
+      processed_cursor BIGINT      NOT NULL DEFAULT 0,
+      updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
   `);
 }
 
-async function persistEvent(event: RawEvent): Promise<void> {
-  await pgPool.query(
-    `
-    INSERT INTO events
-      (event_id, ledger, contract_id, topic, value, tx_hash, closed_at)
-    VALUES ($1, $2, $3, $4, $5, $6, $7)
-    ON CONFLICT (event_id) DO NOTHING
-    `,
-    [
-      event.id,
-      event.ledger,
-      event.contractId,
-      event.topic,
-      event.value,
-      event.txHash,
-      new Date(event.ledgerClosedAt),
-    ]
-  );
+// ── Event normalisation ─────────────────────────────────────────────────────
+
+function toIngestEvent(event: RawEvent): IngestEvent {
+  return {
+    ledgerSequence: event.ledger,
+    eventIndex: event.eventIndex,
+    contractId: event.contractId,
+    type: event.topic[0] ?? "unknown",
+    topic: event.topic,
+    data: {
+      id: event.id,
+      value: event.value,
+      txHash: event.txHash,
+      ledgerClosedAt: event.ledgerClosedAt,
+      pagingToken: event.pagingToken,
+    },
+  };
 }
 
-// ── Event dispatch ────────────────────────────────────────────────────────────
+// ── HTTP + WebSocket server ──────────────────────────────────────────────────
 
-async function handleEvent(event: RawEvent): Promise<void> {
-  await persistEvent(event);
+const httpServer = http.createServer((req, res) => {
+  if (req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "not found" }));
+});
 
-  const eventType = event.topic[0];
-  console.log(`[indexer] ledger=${event.ledger} type=${eventType} tx=${event.txHash}`);
-}
+const wsHandle = attachWebSocketServer(httpServer, bus, { path: "/ws" });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 
 const abortController = new AbortController();
+let shuttingDown = false;
 
-function shutdown(signal: string): void {
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log(`[indexer] Received ${signal}, shutting down…`);
   abortController.abort();
+  await wsHandle.close();
+  httpServer.close();
+  await pgPool.end();
+  console.log("[indexer] Shutdown complete.");
 }
 
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   console.log("[indexer] Starting Linkora indexer");
-  console.log(`[indexer] RPC:      ${STELLAR_RPC_URL}`);
-  console.log(`[indexer] Contract: ${CONTRACT_ID}`);
+  console.log(`[indexer] RPC:        ${STELLAR_RPC_URL}`);
+  console.log(`[indexer] Contract:   ${CONTRACT_ID}`);
   console.log(`[indexer] From ledger: ${START_LEDGER}`);
 
-  await ensureEventsTable();
+  await ensureSchema();
+
+  const pipeline = new IngestPipeline(pgPool, {
+    streamId: CONTRACT_ID,
+    bus,
+    // domainProcessor: wire decoded handlers here. Until contract XDR decoding
+    // is implemented, events are staged + fanned out without domain projection.
+  });
+
+  const processBatch: BatchProcessor = async (events) => {
+    const result = await pipeline.processBatch(events.map(toIngestEvent));
+    return result.cursor;
+  };
+
+  // Resume gap detection from the last committed cursor.
+  const initialCursor = await pipeline.readCursor();
+
+  httpServer.listen(PORT, () => {
+    console.log(`[indexer] HTTP + WS listening on :${PORT} (ws path /ws)`);
+  });
 
   await streamEvents(
     {
       rpcUrl: STELLAR_RPC_URL,
       contractId: CONTRACT_ID,
       startLedger: START_LEDGER,
-      pollIntervalMs: POLL_INTERVAL_MS,
+      initialCursor,
+      ratePerSec: optionalIntEnv("RPC_RATE_LIMIT_PER_SEC"),
+      minPollMs: optionalIntEnv("MIN_POLL_INTERVAL_MS"),
+      maxPollMs: optionalIntEnv("MAX_POLL_INTERVAL_MS"),
     },
-    handleEvent,
+    processBatch,
     abortController.signal
   );
 
+  await wsHandle.close();
+  httpServer.close();
   await pgPool.end();
   console.log("[indexer] Shutdown complete.");
 }

--- a/services/indexer/src/pipeline.ts
+++ b/services/indexer/src/pipeline.ts
@@ -1,0 +1,191 @@
+/**
+ * Exactly-once ingestion pipeline.
+ *
+ * Each batch is processed inside a SINGLE serialisable transaction:
+ *
+ *   1. INSERT every event into the `raw_events` staging table, idempotent via
+ *      `ON CONFLICT (ledger_sequence, event_index) DO NOTHING`.
+ *   2. Project each event into the domain tables (posts, follows, …) via the
+ *      injected `domainProcessor`, which MUST use the same transaction client.
+ *   3. Stamp `raw_events.processed_at` and advance `indexer_state.processed_cursor`.
+ *   4. COMMIT.
+ *
+ * Because the raw ingest, the domain write, and the cursor bump all live in
+ * the same transaction, a crash at any point rolls back the entire batch. On
+ * restart the batch is re-fetched from the (un-advanced) cursor and replayed;
+ * the `ON CONFLICT` clause plus idempotent domain handlers guarantee no
+ * duplicate domain rows — exactly-once semantics.
+ *
+ * The pg types are narrowed to small structural interfaces so the pipeline can
+ * be unit-tested against an in-memory fake without a live database.
+ */
+
+import { EventBus, BusEvent } from "./bus";
+
+export interface QueryResultLike {
+  rowCount: number | null;
+  rows: unknown[];
+}
+
+export interface PgClientLike {
+  query(text: string, params?: unknown[]): Promise<QueryResultLike>;
+  release(): void;
+}
+
+export interface PgPoolLike {
+  connect(): Promise<PgClientLike>;
+}
+
+/** Normalised event flowing through the pipeline. */
+export interface IngestEvent {
+  ledgerSequence: number;
+  eventIndex: number;
+  contractId: string;
+  /** Contract event type — topic[0]. */
+  type: string;
+  topic: string[];
+  /** Decoded (or raw) event body, stored as JSONB. */
+  data: unknown;
+}
+
+/**
+ * Projects a single raw event into the domain tables. MUST issue all its
+ * writes through the provided transaction client so they commit atomically
+ * with the raw ingest and cursor advance. MUST be idempotent (safe to replay).
+ */
+export type DomainProcessor = (
+  client: PgClientLike,
+  event: IngestEvent
+) => Promise<void>;
+
+export interface IngestPipelineOptions {
+  /** Stream identity for the cursor row (typically the contract id). */
+  streamId: string;
+  bus: EventBus;
+  domainProcessor?: DomainProcessor;
+}
+
+export interface BatchResult {
+  committed: boolean;
+  /** Cursor value after this batch (unchanged if nothing committed). */
+  cursor: number;
+  /** Number of raw rows newly inserted (excludes ON CONFLICT skips). */
+  inserted: number;
+}
+
+const noopProcessor: DomainProcessor = async () => {
+  /* default: no domain projection wired — overridden in production */
+};
+
+export class IngestPipeline {
+  private readonly pool: PgPoolLike;
+  private readonly streamId: string;
+  private readonly bus: EventBus;
+  private readonly domainProcessor: DomainProcessor;
+
+  constructor(pool: PgPoolLike, opts: IngestPipelineOptions) {
+    this.pool = pool;
+    this.streamId = opts.streamId;
+    this.bus = opts.bus;
+    this.domainProcessor = opts.domainProcessor ?? noopProcessor;
+  }
+
+  /** Read the last committed cursor for this stream (0 if none). */
+  async readCursor(): Promise<number> {
+    const client = await this.pool.connect();
+    try {
+      const res = await client.query(
+        "SELECT processed_cursor FROM indexer_state WHERE id = $1",
+        [this.streamId]
+      );
+      const row = res.rows[0] as { processed_cursor?: number | string } | undefined;
+      if (!row || row.processed_cursor === undefined) return 0;
+      return Number(row.processed_cursor);
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Process one batch transactionally. Returns once committed (and after the
+   * events have been published to the bus). On any error the transaction is
+   * rolled back and the error rethrown — nothing is persisted or published.
+   */
+  async processBatch(events: IngestEvent[]): Promise<BatchResult> {
+    if (events.length === 0) {
+      return { committed: false, cursor: await this.readCursor(), inserted: 0 };
+    }
+
+    const client = await this.pool.connect();
+    let inserted = 0;
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+
+      // (1) Stage raw events — idempotent on the natural key.
+      for (const ev of events) {
+        const res = await client.query(
+          `INSERT INTO raw_events
+             (ledger_sequence, event_index, contract_id, topic, data)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (ledger_sequence, event_index) DO NOTHING`,
+          [ev.ledgerSequence, ev.eventIndex, ev.contractId, ev.topic, JSON.stringify(ev.data)]
+        );
+        inserted += res.rowCount ?? 0;
+      }
+
+      // (2) Project into domain tables using the SAME transaction client.
+      for (const ev of events) {
+        await this.domainProcessor(client, ev);
+      }
+
+      // (3) Mark processed and advance the cursor — the LAST statements before
+      //     commit, so the cursor never moves ahead of a committed domain write.
+      for (const ev of events) {
+        await client.query(
+          `UPDATE raw_events SET processed_at = NOW()
+           WHERE ledger_sequence = $1 AND event_index = $2`,
+          [ev.ledgerSequence, ev.eventIndex]
+        );
+      }
+
+      const newCursor = events.reduce((m, e) => Math.max(m, e.ledgerSequence), 0);
+      await client.query(
+        `INSERT INTO indexer_state (id, processed_cursor)
+         VALUES ($1, $2)
+         ON CONFLICT (id) DO UPDATE
+           SET processed_cursor = GREATEST(indexer_state.processed_cursor, EXCLUDED.processed_cursor),
+               updated_at = NOW()`,
+        [this.streamId, newCursor]
+      );
+
+      await client.query("COMMIT");
+
+      // (4) Fan out only after the durable commit.
+      for (const ev of events) {
+        this.bus.publish(toBusEvent(ev));
+      }
+
+      return { committed: true, cursor: newCursor, inserted };
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackErr) {
+        console.error("[pipeline] rollback failed:", rollbackErr);
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+function toBusEvent(ev: IngestEvent): BusEvent {
+  return {
+    type: ev.type,
+    ledgerSequence: ev.ledgerSequence,
+    eventIndex: ev.eventIndex,
+    contractId: ev.contractId,
+    topic: ev.topic,
+    data: ev.data,
+  };
+}

--- a/services/indexer/src/poller.ts
+++ b/services/indexer/src/poller.ts
@@ -1,0 +1,58 @@
+/**
+ * Adaptive poll-interval controller.
+ *
+ * Backpressure for the polling loop: when the stream is idle we back off to
+ * avoid hammering the RPC node; when it's busy (a full page came back) we
+ * speed up to keep latency low.
+ *
+ *   - empty batch (0 events)      → double the interval, capped at `maxMs`
+ *   - full page (>= pageSize)     → halve the interval, floored at `minMs`
+ *   - partial batch (1..pageSize) → keep the current interval
+ */
+
+export interface AdaptivePollOptions {
+  /** Lower bound on the interval. Default 100ms. */
+  minMs?: number;
+  /** Upper bound on the interval. Default 5000ms. */
+  maxMs?: number;
+  /** Page size that counts as a "full" page. */
+  pageSize: number;
+  /** Starting interval. Defaults to maxMs (start slow, speed up under load). */
+  startMs?: number;
+}
+
+export class AdaptivePoll {
+  readonly minMs: number;
+  readonly maxMs: number;
+  private readonly pageSize: number;
+  private current: number;
+
+  constructor(opts: AdaptivePollOptions) {
+    this.minMs = opts.minMs ?? 100;
+    this.maxMs = opts.maxMs ?? 5_000;
+    this.pageSize = opts.pageSize;
+    this.current = this.clamp(opts.startMs ?? this.maxMs);
+  }
+
+  /** Current poll interval in milliseconds. */
+  get intervalMs(): number {
+    return this.current;
+  }
+
+  /**
+   * Record the size of the batch just returned and return the next interval.
+   */
+  next(batchSize: number): number {
+    if (batchSize <= 0) {
+      this.current = this.clamp(this.current * 2);
+    } else if (batchSize >= this.pageSize) {
+      this.current = this.clamp(this.current / 2);
+    }
+    // partial batch: hold steady
+    return this.current;
+  }
+
+  private clamp(ms: number): number {
+    return Math.min(this.maxMs, Math.max(this.minMs, Math.round(ms)));
+  }
+}

--- a/services/indexer/src/ratelimit.ts
+++ b/services/indexer/src/ratelimit.ts
@@ -1,0 +1,103 @@
+/**
+ * Token-bucket rate limiter for outbound RPC calls.
+ *
+ * Smooths request bursts to a sustainable rate (default 10 req/s) so the
+ * indexer doesn't trip RPC-side 429s under high event volume. The bucket
+ * refills continuously at `ratePerSec` and holds at most `burst` tokens.
+ *
+ * The clock and sleep functions are injectable so the limiter can be tested
+ * deterministically without real timers.
+ */
+
+export interface TokenBucketOptions {
+  /** Sustained refill rate in tokens per second. */
+  ratePerSec: number;
+  /** Maximum tokens the bucket can hold (burst capacity). Defaults to ratePerSec. */
+  burst?: number;
+  /** Monotonic clock in milliseconds. Defaults to Date.now. */
+  now?: () => number;
+  /** Async sleep used when waiting for a token. Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export class TokenBucket {
+  private readonly ratePerSec: number;
+  private readonly capacity: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  private tokens: number;
+  private lastRefill: number;
+
+  constructor(opts: TokenBucketOptions) {
+    if (opts.ratePerSec <= 0) {
+      throw new Error("TokenBucket ratePerSec must be > 0");
+    }
+    this.ratePerSec = opts.ratePerSec;
+    this.capacity = opts.burst ?? opts.ratePerSec;
+    this.now = opts.now ?? Date.now;
+    this.sleep = opts.sleep ?? defaultSleep;
+    this.tokens = this.capacity;
+    this.lastRefill = this.now();
+  }
+
+  /** Refill the bucket based on elapsed wall-clock time. */
+  private refill(): void {
+    const ts = this.now();
+    const elapsedSec = (ts - this.lastRefill) / 1000;
+    if (elapsedSec <= 0) return;
+    this.tokens = Math.min(this.capacity, this.tokens + elapsedSec * this.ratePerSec);
+    this.lastRefill = ts;
+  }
+
+  /**
+   * Try to take a token without waiting. Returns true if a token was
+   * available (and consumed), false otherwise.
+   */
+  tryRemove(): boolean {
+    this.refill();
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+
+  /** Milliseconds until at least one token is available. */
+  msUntilNextToken(): number {
+    this.refill();
+    if (this.tokens >= 1) return 0;
+    const deficit = 1 - this.tokens;
+    return Math.ceil((deficit / this.ratePerSec) * 1000);
+  }
+
+  /**
+   * Acquire a token, waiting (sleeping) as long as necessary. Resolves once a
+   * token has been consumed.
+   */
+  async acquire(): Promise<void> {
+    // Loop because, after sleeping, a competing acquirer may have taken the
+    // refilled token first.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (this.tryRemove()) return;
+      await this.sleep(this.msUntilNextToken());
+    }
+  }
+}
+
+/**
+ * Build a token bucket from env, with sane defaults.
+ *   RPC_RATE_LIMIT_PER_SEC  — sustained rate (default 10)
+ *   RPC_RATE_LIMIT_BURST    — burst capacity (default = rate)
+ */
+export function rateLimiterFromEnv(env: NodeJS.ProcessEnv = process.env): TokenBucket {
+  const ratePerSec = env.RPC_RATE_LIMIT_PER_SEC
+    ? Number(env.RPC_RATE_LIMIT_PER_SEC)
+    : 10;
+  const burst = env.RPC_RATE_LIMIT_BURST ? Number(env.RPC_RATE_LIMIT_BURST) : undefined;
+  return new TokenBucket({ ratePerSec, burst });
+}

--- a/services/indexer/src/stream.ts
+++ b/services/indexer/src/stream.ts
@@ -1,14 +1,30 @@
 /**
  * Soroban event streaming via Horizon/Soroban RPC.
  *
- * Polls getEvents on the configured RPC endpoint and yields raw contract
- * events for the Linkora contract. Callers provide a cursor (latest processed
- * ledger) so the stream can resume after a restart.
+ * Polls `getEvents` on the configured RPC endpoint and feeds batches of raw
+ * contract events to a processor. Production concerns handled here:
+ *
+ *   - Backpressure: a token-bucket rate limiter caps outbound RPC rate, and an
+ *     adaptive poll interval backs off when idle / speeds up under load.
+ *   - 429 resilience: rate-limit responses trigger exponential backoff with
+ *     retries; no events are dropped — the same window is re-fetched.
+ *   - Gap detection: after each batch the first event's ledger is compared to
+ *     `cursor + 1`; a jump triggers a structured `gap_detected` log and a
+ *     targeted backfill of the missing range before the batch is processed.
+ *
+ * The clock, sleep, fetch implementation and rate limiter are all injectable so
+ * the loop can be driven deterministically in tests.
  */
+
+import { TokenBucket } from "./ratelimit";
+import { AdaptivePoll } from "./poller";
+import { detectGap } from "./gap";
 
 export interface RawEvent {
   type: string;
   ledger: number;
+  /** Index of this event within its ledger (parsed from the RPC event id). */
+  eventIndex: number;
   ledgerClosedAt: string;
   contractId: string;
   id: string;
@@ -22,19 +38,83 @@ export interface StreamConfig {
   rpcUrl: string;
   contractId: string;
   startLedger: number;
-  pollIntervalMs?: number;
+  /** Cursor (last fully processed ledger) to resume gap detection from. */
+  initialCursor?: number;
+  /** Adaptive poll bounds. */
+  minPollMs?: number;
+  maxPollMs?: number;
+  /** Token-bucket sustained rate (req/s). */
+  ratePerSec?: number;
+  /** 429 / network backoff tuning. */
+  maxRetries?: number;
+  backoffBaseMs?: number;
+  backoffMaxMs?: number;
 }
 
-export type EventHandler = (event: RawEvent) => Promise<void>;
+/**
+ * Processes a batch of events and returns the new cursor (the highest ledger
+ * fully processed). Implemented by the ingest pipeline. MUST be exactly-once.
+ */
+export type BatchProcessor = (events: RawEvent[]) => Promise<number>;
 
-const DEFAULT_POLL_INTERVAL_MS = 5_000;
+export interface StreamDeps {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  rateLimiter?: TokenBucket;
+}
+
+const DEFAULT_MIN_POLL_MS = 100;
+const DEFAULT_MAX_POLL_MS = 5_000;
+const DEFAULT_RATE_PER_SEC = 10;
+const DEFAULT_MAX_RETRIES = 6;
+const DEFAULT_BACKOFF_BASE_MS = 250;
+const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const MAX_EVENTS_PER_PAGE = 100;
 
-async function fetchEvents(
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Error carrying the HTTP status of a failed RPC call (e.g. 429). */
+export class RpcError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = "RpcError";
+  }
+}
+
+/**
+ * Parse the event index out of a Soroban event id of the form
+ * "<toid>-<index>" (e.g. "0004023007-0000000003"). Falls back to `ordinal`
+ * (the event's position in the batch) when the id is malformed.
+ */
+export function parseEventIndex(id: string, ordinal: number): number {
+  const dash = id.lastIndexOf("-");
+  if (dash >= 0) {
+    const parsed = Number(id.slice(dash + 1));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return ordinal;
+}
+
+interface RawRpcEvent {
+  type: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  contractId: string;
+  id: string;
+  pagingToken: string;
+  topic: string[];
+  value: string;
+  txHash: string;
+}
+
+/** A single getEvents RPC call. Throws RpcError on non-2xx / RPC error. */
+async function fetchEventsOnce(
+  fetchImpl: typeof fetch,
   rpcUrl: string,
   contractId: string,
   startLedger: number,
-  cursor?: string
+  cursor: string | undefined
 ): Promise<{ events: RawEvent[]; latestLedger: number }> {
   const body: Record<string, unknown> = {
     jsonrpc: "2.0",
@@ -42,97 +122,247 @@ async function fetchEvents(
     method: "getEvents",
     params: {
       startLedger,
-      filters: [
-        {
-          type: "contract",
-          contractIds: [contractId],
-        },
-      ],
-      pagination: {
-        limit: MAX_EVENTS_PER_PAGE,
-        ...(cursor ? { cursor } : {}),
-      },
+      filters: [{ type: "contract", contractIds: [contractId] }],
+      pagination: { limit: MAX_EVENTS_PER_PAGE, ...(cursor ? { cursor } : {}) },
     },
   };
 
-  const response = await fetch(rpcUrl, {
+  const response = await fetchImpl(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
 
   if (!response.ok) {
-    throw new Error(`RPC request failed: ${response.status} ${response.statusText}`);
+    throw new RpcError(
+      `RPC request failed: ${response.status} ${response.statusText}`,
+      response.status
+    );
   }
 
   const json = (await response.json()) as {
-    result?: {
-      events: RawEvent[];
-      latestLedger: number;
-    };
+    result?: { events: RawRpcEvent[]; latestLedger: number };
     error?: { message: string };
   };
 
   if (json.error) {
-    throw new Error(`RPC error: ${json.error.message}`);
+    throw new RpcError(`RPC error: ${json.error.message}`, 0);
   }
 
-  return {
-    events: json.result?.events ?? [],
-    latestLedger: json.result?.latestLedger ?? startLedger,
-  };
+  const rawEvents = json.result?.events ?? [];
+  const events: RawEvent[] = rawEvents.map((e, ordinal) => ({
+    ...e,
+    eventIndex: parseEventIndex(e.id, ordinal),
+  }));
+
+  return { events, latestLedger: json.result?.latestLedger ?? startLedger };
 }
 
 /**
- * Stream Soroban contract events and invoke `handler` for each.
+ * getEvents with backpressure and 429 resilience: acquires a rate-limit token
+ * first, then retries on 429 (and transient errors) with exponential backoff.
+ * The fetched window is never abandoned, so no events are dropped.
+ */
+async function fetchEventsResilient(
+  deps: Required<Pick<StreamDeps, "fetchImpl" | "sleep" | "rateLimiter">>,
+  cfg: Required<Pick<StreamConfig, "maxRetries" | "backoffBaseMs" | "backoffMaxMs">>,
+  rpcUrl: string,
+  contractId: string,
+  startLedger: number,
+  cursor: string | undefined,
+  signal: AbortSignal
+): Promise<{ events: RawEvent[]; latestLedger: number }> {
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (signal.aborted) return { events: [], latestLedger: startLedger };
+    await deps.rateLimiter.acquire();
+    try {
+      return await fetchEventsOnce(deps.fetchImpl, rpcUrl, contractId, startLedger, cursor);
+    } catch (err) {
+      const status = err instanceof RpcError ? err.status : -1;
+      attempt += 1;
+      if (attempt > cfg.maxRetries) throw err;
+
+      const backoff = Math.min(
+        cfg.backoffMaxMs,
+        cfg.backoffBaseMs * 2 ** (attempt - 1)
+      );
+      if (status === 429) {
+        console.warn(
+          `[stream] 429 rate-limited (attempt ${attempt}/${cfg.maxRetries}), backing off ${backoff}ms`
+        );
+      } else {
+        console.warn(
+          `[stream] RPC error (attempt ${attempt}/${cfg.maxRetries}), backing off ${backoff}ms:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+      await deps.sleep(backoff);
+    }
+  }
+}
+
+/**
+ * Fetch every event in the inclusive ledger range [fromLedger, toLedger],
+ * paginating as needed. Used to backfill a detected gap.
+ */
+async function fetchRange(
+  deps: Required<Pick<StreamDeps, "fetchImpl" | "sleep" | "rateLimiter">>,
+  cfg: Required<Pick<StreamConfig, "maxRetries" | "backoffBaseMs" | "backoffMaxMs">>,
+  rpcUrl: string,
+  contractId: string,
+  fromLedger: number,
+  toLedger: number,
+  signal: AbortSignal
+): Promise<RawEvent[]> {
+  const collected: RawEvent[] = [];
+  let cursor: string | undefined;
+  while (!signal.aborted) {
+    const { events } = await fetchEventsResilient(
+      deps,
+      cfg,
+      rpcUrl,
+      contractId,
+      fromLedger,
+      cursor,
+      signal
+    );
+    const inRange = events.filter((e) => e.ledger <= toLedger);
+    collected.push(...inRange);
+
+    const lastEvent = events[events.length - 1];
+    const moreToFetch =
+      events.length === MAX_EVENTS_PER_PAGE &&
+      lastEvent !== undefined &&
+      lastEvent.ledger <= toLedger;
+    if (!moreToFetch) break;
+    cursor = lastEvent.pagingToken;
+  }
+  return collected;
+}
+
+function waitWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted || ms <= 0) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+/**
+ * Stream Soroban contract events, invoking `processBatch` for each batch.
  *
- * Runs until `signal` is aborted. Maintains a cursor so restarts resume
- * without re-processing events. Returns the latest ledger seen.
+ * Runs until `signal` is aborted. Maintains a cursor (last fully processed
+ * ledger) returned by the processor so restarts resume cleanly, and applies
+ * rate limiting, adaptive polling, 429 backoff and gap backfill along the way.
  */
 export async function streamEvents(
   config: StreamConfig,
-  handler: EventHandler,
-  signal: AbortSignal
+  processBatch: BatchProcessor,
+  signal: AbortSignal,
+  deps: StreamDeps = {}
 ): Promise<void> {
-  const pollMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  let cursor: string | undefined;
+  const resolved = {
+    fetchImpl: deps.fetchImpl ?? fetch,
+    sleep: deps.sleep ?? defaultSleep,
+    rateLimiter:
+      deps.rateLimiter ??
+      new TokenBucket({ ratePerSec: config.ratePerSec ?? DEFAULT_RATE_PER_SEC }),
+  };
+  const backoffCfg = {
+    maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    backoffBaseMs: config.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS,
+    backoffMaxMs: config.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS,
+  };
+  const poll = new AdaptivePoll({
+    minMs: config.minPollMs ?? DEFAULT_MIN_POLL_MS,
+    maxMs: config.maxPollMs ?? DEFAULT_MAX_POLL_MS,
+    pageSize: MAX_EVENTS_PER_PAGE,
+  });
+
+  let cursor = config.initialCursor ?? 0;
   let startLedger = config.startLedger;
+  let pagingCursor: string | undefined;
 
   console.log(
-    `[stream] Starting from ledger ${startLedger}, contract=${config.contractId}`
+    `[stream] Starting from ledger ${startLedger} (cursor ${cursor}), contract=${config.contractId}`
   );
 
   while (!signal.aborted) {
     try {
-      const { events, latestLedger } = await fetchEvents(
+      const { events, latestLedger } = await fetchEventsResilient(
+        resolved,
+        backoffCfg,
         config.rpcUrl,
         config.contractId,
         startLedger,
-        cursor
+        pagingCursor,
+        signal
       );
 
-      for (const event of events) {
-        if (signal.aborted) break;
-        await handler(event);
-        cursor = event.pagingToken;
+      if (signal.aborted) break;
+
+      // ── Gap detection ────────────────────────────────────────────────────
+      const firstLedger = events[0]?.ledger;
+      const gap = detectGap(firstLedger, cursor);
+      if (gap.hasGap && gap.fromLedger !== undefined && gap.toLedger !== undefined) {
+        console.warn(
+          JSON.stringify({
+            metric: "gap_detected",
+            stream: config.contractId,
+            expectedLedger: gap.fromLedger,
+            receivedLedger: firstLedger,
+            missingFrom: gap.fromLedger,
+            missingTo: gap.toLedger,
+          })
+        );
+        const backfilled = await fetchRange(
+          resolved,
+          backoffCfg,
+          config.rpcUrl,
+          config.contractId,
+          gap.fromLedger,
+          gap.toLedger,
+          signal
+        );
+        if (backfilled.length > 0) {
+          cursor = await processBatch(backfilled);
+        }
+      }
+
+      // ── Process the current batch ─────────────────────────────────────────
+      if (events.length > 0) {
+        cursor = await processBatch(events);
       }
 
       if (events.length === MAX_EVENTS_PER_PAGE) {
+        // Full page: page through the rest of the window immediately (no wait),
+        // recording the speed-up.
+        pagingCursor = events[events.length - 1].pagingToken;
+        poll.next(events.length);
         continue;
       }
 
-      startLedger = latestLedger;
+      // Window drained: reset paging, advance startLedger, and apply the
+      // adaptive wait (empty → back off, partial → hold steady).
+      pagingCursor = undefined;
+      startLedger = Math.max(latestLedger, cursor + 1);
+      await waitWithAbort(poll.next(events.length), signal);
     } catch (err) {
-      console.error("[stream] Error fetching events:", err);
+      console.error("[stream] Error processing batch:", err);
+      await waitWithAbort(poll.intervalMs, signal);
     }
-
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, pollMs);
-      signal.addEventListener("abort", () => {
-        clearTimeout(timer);
-        resolve();
-      });
-    });
   }
 
   console.log("[stream] Stopped.");

--- a/services/indexer/src/ws.ts
+++ b/services/indexer/src/ws.ts
@@ -1,0 +1,162 @@
+/**
+ * WebSocket fanout handler.
+ *
+ * Bridges the in-process event bus to connected WebSocket clients on the `/ws`
+ * path. Every committed event is pushed as a `{ type, payload }` JSON frame.
+ *
+ * Clients may narrow what they receive by sending a subscribe control frame:
+ *   { "action": "subscribe", "types": ["PostCreated", "Follow"] }
+ * Sending `["*"]` or omitting the filter (the default) delivers every event.
+ *
+ * Liveness is maintained with a protocol-level ping/pong heartbeat every 15s;
+ * clients that miss a heartbeat are terminated. See docs/indexer/WEBSOCKET_API.md.
+ */
+
+import { Server as HttpServer } from "http";
+import { WebSocketServer, WebSocket, RawData } from "ws";
+import { EventBus, BusEvent, ALL_EVENTS } from "./bus";
+
+export interface WsServerOptions {
+  /** URL path to accept WebSocket upgrades on. Default "/ws". */
+  path?: string;
+  /** Heartbeat interval in milliseconds. Default 15000. */
+  heartbeatMs?: number;
+}
+
+interface ClientState {
+  isAlive: boolean;
+  /** Event types this client wants; null means "all". */
+  types: Set<string> | null;
+}
+
+export interface WsHandle {
+  wss: WebSocketServer;
+  /** Number of currently connected clients. */
+  clientCount(): number;
+  /** Stop heartbeats, unsubscribe from the bus, and close all sockets. */
+  close(): Promise<void>;
+}
+
+const DEFAULT_HEARTBEAT_MS = 15_000;
+
+/**
+ * Attach a WebSocket server to an existing HTTP server and wire it to the bus.
+ */
+export function attachWebSocketServer(
+  httpServer: HttpServer,
+  bus: EventBus,
+  opts: WsServerOptions = {}
+): WsHandle {
+  const path = opts.path ?? "/ws";
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+
+  const wss = new WebSocketServer({ server: httpServer, path });
+  const clients = new Map<WebSocket, ClientState>();
+
+  wss.on("connection", (ws: WebSocket) => {
+    const state: ClientState = { isAlive: true, types: null };
+    clients.set(ws, state);
+
+    ws.on("pong", () => {
+      state.isAlive = true;
+    });
+
+    ws.on("message", (raw: RawData) => {
+      handleControlFrame(ws, state, raw);
+    });
+
+    ws.on("close", () => {
+      clients.delete(ws);
+    });
+
+    ws.on("error", (err) => {
+      console.error("[ws] socket error:", err);
+      clients.delete(ws);
+    });
+  });
+
+  // ── Bus → clients fanout ──────────────────────────────────────────────────
+  const unsubscribe = bus.on(ALL_EVENTS, (event: BusEvent) => {
+    const frame = JSON.stringify({ type: event.type, payload: event });
+    for (const [ws, state] of clients) {
+      if (ws.readyState !== WebSocket.OPEN) continue;
+      if (state.types !== null && !state.types.has(event.type)) continue;
+      ws.send(frame);
+    }
+  });
+
+  // ── Heartbeat ─────────────────────────────────────────────────────────────
+  const heartbeat = setInterval(() => {
+    for (const [ws, state] of clients) {
+      if (!state.isAlive) {
+        clients.delete(ws);
+        ws.terminate();
+        continue;
+      }
+      state.isAlive = false;
+      ws.ping();
+    }
+  }, heartbeatMs);
+  // Don't keep the event loop alive solely for heartbeats.
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
+
+  return {
+    wss,
+    clientCount: () => clients.size,
+    close: () =>
+      new Promise<void>((resolve) => {
+        clearInterval(heartbeat);
+        unsubscribe();
+        for (const ws of clients.keys()) {
+          ws.close(1001, "server shutting down");
+        }
+        clients.clear();
+        wss.close(() => resolve());
+      }),
+  };
+}
+
+function handleControlFrame(ws: WebSocket, state: ClientState, raw: RawData): void {
+  let msg: unknown;
+  try {
+    msg = JSON.parse(raw.toString());
+  } catch {
+    sendError(ws, "invalid JSON control frame");
+    return;
+  }
+
+  if (typeof msg !== "object" || msg === null) {
+    sendError(ws, "control frame must be an object");
+    return;
+  }
+
+  const { action, types } = msg as { action?: string; types?: unknown };
+  if (action !== "subscribe") {
+    sendError(ws, `unknown action: ${String(action)}`);
+    return;
+  }
+
+  if (!Array.isArray(types) || !types.every((t) => typeof t === "string")) {
+    sendError(ws, "subscribe requires a string[] 'types' field");
+    return;
+  }
+
+  if (types.length === 0 || types.includes(ALL_EVENTS)) {
+    state.types = null; // all events
+  } else {
+    state.types = new Set(types as string[]);
+  }
+
+  ws.send(
+    JSON.stringify({
+      type: "subscribed",
+      payload: { types: state.types === null ? [ALL_EVENTS] : [...state.types] },
+    })
+  );
+}
+
+function sendError(ws: WebSocket, message: string): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: "error", payload: { message } }));
+  }
+}


### PR DESCRIPTION
Closes #533

## Summary

Reworks the indexer's event stream into a production-grade, exactly-once pipeline with backpressure, in-process fanout, and gap detection. Replaces the fixed-interval `getEvents` poll in `services/indexer/src/stream.ts`.

## What changed

### Exactly-once ingestion
- New `raw_events` staging table (migration `006_raw_events.sql`): `(id BIGSERIAL, ledger_sequence BIGINT, event_index INT, contract_id TEXT, topic TEXT[], data JSONB, processed_at TIMESTAMPTZ, PRIMARY KEY(ledger_sequence, event_index))`.
- Each batch runs in a **single serialisable transaction**: stage into `raw_events` (`ON CONFLICT DO NOTHING`) → project into domain tables via the same tx client → advance `indexer_state.processed_cursor` as the **last** statement before `COMMIT`. A crash rolls everything back together, so replay yields no duplicate domain rows. (`src/pipeline.ts`)

### Backpressure & adaptive polling
- Token-bucket rate limiter for RPC calls — default 10 req/s, `RPC_RATE_LIMIT_PER_SEC`. (`src/ratelimit.ts`)
- Adaptive poll interval: doubles (up to 5s) on an empty batch, halves (down to 100ms) on a full page. (`src/poller.ts`)
- `429` responses trigger exponential backoff with retries; the window is re-fetched so no events are dropped.

### Internal pub/sub fanout
- In-process `EventBus` (Node `EventEmitter`) with typed per-event-type channels plus a wildcard. (`src/bus.ts`)
- `/ws` WebSocket handler subscribes to the bus and pushes `{ type, payload }` JSON frames, with type subscriptions, 15s ping/pong heartbeat, and clean disconnection. (`src/ws.ts`)
- WebSocket message schema documented in `docs/indexer/WEBSOCKET_API.md`.

### Gap detection
- After each batch, verifies `batch[0].ledger_sequence == cursor + 1`. On a gap (e.g. RPC node failover mid-sequence) it emits a structured `gap_detected` log and backfills the missing range before continuing. (`src/gap.ts`)

## Tests
- **Exactly-once**: crash simulated between raw ingest and domain write → no duplicate rows on restart; idempotent replay; bus publishes only after commit.
- **Backpressure**: mocked `429` → verified exponential backoff and no dropped events.
- **WebSocket**: clients receive events within 200ms of ingestion, including under a synthetic burst.
- Unit tests for the bus, token bucket, adaptive poller, and gap detection.

`npm test` → **95 passed (13 suites)**, including all pre-existing indexer handler tests. `tsc` typechecks clean.

## Acceptance criteria
- [x] No duplicate domain rows under any crash scenario
- [x] Adaptive polling implemented and tested
- [x] WebSocket push implemented with documented schema
- [x] Gap detection emits structured log and triggers backfill
- [x] All existing indexer tests pass

## Notes
- The pipeline's `domainProcessor` is an injectable seam: the exactly-once *mechanism* is fully implemented/tested, but wiring the existing typed handlers requires Soroban XDR decoding, which is out of scope for this issue (the previous `index.ts` also only logged events). A clear marker shows where decoded handlers plug in.
- The existing `Dockerfile` runs `npm ci --omit=dev` before `tsc` build (which needs dev `@types`/`typescript`) — a pre-existing issue left untouched here.
