### PR TITLE
feat(web): implement search results page

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,3 +1,5 @@
 .next/
 node_modules/
 .env*.local
+test-results/
+*.tsbuildinfo

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "echo 'No lint configured for apps/web stub'",
+    "test:e2e": "playwright test",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm --filter apps-web dev --hostname 127.0.0.1",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/web/src/app/search/SearchPageClient.tsx
+++ b/apps/web/src/app/search/SearchPageClient.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Post, PostCard, PostCardSkeleton, getPostDate, getPostTipTotal } from "@/components/PostCard";
+import { Profile, ProfileCard } from "@/components/ProfileCard";
+import SearchBar from "@/components/SearchBar";
+
+type Tab = "posts" | "profiles";
+type Sort = "relevance" | "recent" | "most_tipped";
+
+const INDEXER_API_URL = process.env.NEXT_PUBLIC_INDEXER_API_URL ?? "http://localhost:3001";
+
+function readTab(value: string | null): Tab {
+  return value === "profiles" ? "profiles" : "posts";
+}
+
+function readSort(value: string | null): Sort {
+  if (value === "recent" || value === "most_tipped") return value;
+  return "relevance";
+}
+
+function toDateStart(value: string): number | null {
+  if (!value) return null;
+  const time = new Date(`${value}T00:00:00`).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function toDateEnd(value: string): number | null {
+  if (!value) return null;
+  const time = new Date(`${value}T23:59:59.999`).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function readPosts(data: unknown): Post[] {
+  if (Array.isArray(data)) return data as Post[];
+  if (data && typeof data === "object" && Array.isArray((data as { posts?: unknown }).posts)) {
+    return (data as { posts: Post[] }).posts;
+  }
+  return [];
+}
+
+function readProfiles(data: unknown): Profile[] {
+  if (Array.isArray(data)) return data as Profile[];
+  if (data && typeof data === "object" && Array.isArray((data as { profiles?: unknown }).profiles)) {
+    return (data as { profiles: Profile[] }).profiles;
+  }
+  return [];
+}
+
+export function SearchPageClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const query = searchParams.get("q") ?? "";
+  const activeTab = readTab(searchParams.get("tab"));
+  const sort = readSort(searchParams.get("sort"));
+  const from = searchParams.get("from") ?? "";
+  const to = searchParams.get("to") ?? "";
+
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateParams = (updates: Record<string, string>) => {
+    const next = new URLSearchParams(searchParams.toString());
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value) next.set(key, value);
+      else next.delete(key);
+    });
+
+    router.replace(`/search?${next.toString()}`, { scroll: false });
+  };
+
+  const submitSearch = (nextQuery: string) => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.set("q", nextQuery);
+    next.delete("from");
+    next.delete("to");
+    router.push(`/search?${next.toString()}`);
+  };
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setPosts([]);
+      setProfiles([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const path = activeTab === "profiles" ? "/api/profiles/search" : "/api/search";
+
+    setLoading(true);
+    setError(null);
+
+    fetch(`${INDEXER_API_URL}${path}?q=${encodeURIComponent(trimmed)}`, {
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("Search request failed.");
+        return response.json();
+      })
+      .then((data) => {
+        if (activeTab === "profiles") {
+          setProfiles(readProfiles(data));
+        } else {
+          setPosts(readPosts(data));
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Search request failed.");
+        if (activeTab === "profiles") setProfiles([]);
+        else setPosts([]);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [activeTab, query]);
+
+  const visiblePosts = useMemo(() => {
+    const fromTime = toDateStart(from);
+    const toTime = toDateEnd(to);
+
+    const filtered = posts.filter((post) => {
+      const date = getPostDate(post);
+      if (!date) return !fromTime && !toTime;
+      const time = date.getTime();
+      return (fromTime === null || time >= fromTime) && (toTime === null || time <= toTime);
+    });
+
+    if (sort === "recent") {
+      return [...filtered].sort((a, b) => (getPostDate(b)?.getTime() ?? 0) - (getPostDate(a)?.getTime() ?? 0));
+    }
+
+    if (sort === "most_tipped") {
+      return [...filtered].sort((a, b) => getPostTipTotal(b) - getPostTipTotal(a));
+    }
+
+    return filtered;
+  }, [from, posts, sort, to]);
+
+  const hasQuery = query.trim().length > 0;
+  const hasPostResults = visiblePosts.length > 0;
+  const hasProfileResults = profiles.length > 0;
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-10">
+      <div className="mb-8">
+        <h1 className="mb-4 text-3xl font-bold">Search</h1>
+        <SearchBar
+          onSearch={submitSearch}
+          initialValue={query}
+          placeholder="Search posts and profiles"
+          className="w-full max-w-2xl"
+        />
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex rounded-lg border border-[var(--border)] bg-[var(--muted)] p-1">
+          <button
+            type="button"
+            onClick={() => updateParams({ tab: "posts" })}
+            className={`rounded-md px-4 py-2 text-sm font-semibold ${activeTab === "posts" ? "bg-violet-600 text-white" : "text-[var(--text-muted)] hover:text-[var(--foreground)]"}`}
+          >
+            Posts
+          </button>
+          <button
+            type="button"
+            onClick={() => updateParams({ tab: "profiles" })}
+            className={`rounded-md px-4 py-2 text-sm font-semibold ${activeTab === "profiles" ? "bg-violet-600 text-white" : "text-[var(--text-muted)] hover:text-[var(--foreground)]"}`}
+          >
+            Profiles
+          </button>
+        </div>
+
+        {activeTab === "posts" && (
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="text-sm text-[var(--text-muted)]">
+              Sort
+              <select
+                value={sort}
+                onChange={(event) => updateParams({ sort: event.target.value })}
+                className="ml-2 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-[var(--foreground)]"
+              >
+                <option value="relevance">Relevance</option>
+                <option value="recent">Recent</option>
+                <option value="most_tipped">Most Tipped</option>
+              </select>
+            </label>
+            <label className="text-sm text-[var(--text-muted)]">
+              From
+              <input
+                type="date"
+                value={from}
+                onChange={(event) => updateParams({ from: event.target.value })}
+                className="ml-2 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-sm text-[var(--text-muted)]">
+              To
+              <input
+                type="date"
+                value={to}
+                onChange={(event) => updateParams({ to: event.target.value })}
+                className="ml-2 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-[var(--foreground)]"
+              />
+            </label>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-500/50 bg-red-950/40 p-4 text-red-200">
+          {error}
+        </div>
+      )}
+
+      {!hasQuery && (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--muted)] p-8 text-center text-[var(--text-muted)]">
+          Enter a search term to find posts and profiles.
+        </div>
+      )}
+
+      {hasQuery && activeTab === "posts" && (
+        <div className="space-y-4" aria-live="polite">
+          {loading && Array.from({ length: 5 }, (_, index) => <PostCardSkeleton key={index} />)}
+          {!loading && !error && hasPostResults && visiblePosts.map((post) => (
+            <PostCard key={post.id} post={post} query={query} />
+          ))}
+          {!loading && !error && !hasPostResults && (
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--muted)] p-8 text-center text-[var(--text-muted)]">
+              No posts found for "{query}".
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasQuery && activeTab === "profiles" && (
+        <div className="space-y-4" aria-live="polite">
+          {loading && (
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--muted)] p-8 text-center text-[var(--text-muted)]">
+              Loading profiles...
+            </div>
+          )}
+          {!loading && !error && hasProfileResults && profiles.map((profile) => (
+            <ProfileCard key={profile.address} profile={profile} />
+          ))}
+          {!loading && !error && !hasProfileResults && (
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--muted)] p-8 text-center text-[var(--text-muted)]">
+              No profiles found for "{query}".
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { SearchPageClient } from "./SearchPageClient";
+
+type BoundaryProps = {
+  fallback: JSX.Element;
+  children: JSX.Element;
+};
+
+const SuspenseBoundary = Suspense as unknown as (props: BoundaryProps) => JSX.Element;
+
+export default function SearchPage() {
+  return (
+    <SuspenseBoundary fallback={<div className="mx-auto max-w-5xl px-4 py-10">Loading search...</div>}>
+      <SearchPageClient />
+    </SuspenseBoundary>
+  );
+}

--- a/apps/web/src/components/NavBar.tsx
+++ b/apps/web/src/components/NavBar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useWallet } from "@/hooks/useWallet";
+import SearchBar from "@/components/SearchBar";
 
 /** Truncates a Stellar address to G…XXXX format */
 function truncateAddress(address: string): string {
@@ -8,11 +10,12 @@ function truncateAddress(address: string): string {
 }
 
 export function NavBar() {
+  const router = useRouter();
   const { address, connected, network, connect, disconnect } = useWallet();
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-[var(--border)] bg-[var(--background)]/80 backdrop-blur-sm">
-      <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+      <nav className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         {/* Brand */}
         <a
           href="/"
@@ -20,6 +23,12 @@ export function NavBar() {
         >
           Linkora
         </a>
+
+        <SearchBar
+          onSearch={(query) => router.push(`/search?q=${encodeURIComponent(query)}`)}
+          placeholder="Search posts and profiles"
+          className="w-full max-w-xl sm:flex-1"
+        />
 
         {/* Right side */}
         <div className="flex items-center gap-3">

--- a/apps/web/src/components/PostCard.tsx
+++ b/apps/web/src/components/PostCard.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+export interface Post {
+  id: string | number;
+  author: string;
+  content: string;
+  tip_total?: string | number;
+  timestamp?: string | number;
+  created_at?: string;
+}
+
+interface PostCardProps {
+  post: Post;
+  query?: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function highlightText(text: string, query = "") {
+  const trimmed = query.trim();
+  if (!trimmed) return text;
+
+  const parts = text.split(new RegExp(`(${escapeRegExp(trimmed)})`, "gi"));
+  return parts.map((part, index) =>
+    part.toLowerCase() === trimmed.toLowerCase() ? (
+      <mark key={`${part}-${index}`} className="rounded bg-yellow-300 px-1 text-black">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}
+
+export function getPostDate(post: Post): Date | null {
+  const raw = post.created_at ?? post.timestamp;
+  if (raw === undefined || raw === null || raw === "") return null;
+
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) {
+    return new Date(numeric < 1_000_000_000_000 ? numeric * 1000 : numeric);
+  }
+
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getPostTipTotal(post: Post): number {
+  const value = Number(post.tip_total ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function formatDate(post: Post): string {
+  const date = getPostDate(post);
+  return date ? date.toLocaleDateString() : "Unknown date";
+}
+
+function formatAuthor(author: string): string {
+  return author.length > 16 ? `${author.slice(0, 6)}...${author.slice(-4)}` : author;
+}
+
+export function PostCard({ post, query }: PostCardProps) {
+  return (
+    <article className="rounded-lg border border-[var(--border)] bg-[var(--muted)] p-5">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-sm text-[var(--text-muted)]">
+        <span title={post.author}>By {formatAuthor(post.author)}</span>
+        <time>{formatDate(post)}</time>
+      </div>
+
+      <p className="whitespace-pre-wrap break-words leading-7 text-[var(--foreground)]">
+        {highlightText(post.content, query)}
+      </p>
+
+      <div className="mt-4 text-sm font-medium text-violet-300">
+        Tips: {getPostTipTotal(post)}
+      </div>
+    </article>
+  );
+}
+
+export function PostCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-lg border border-[var(--border)] bg-[var(--muted)] p-5">
+      <div className="mb-4 flex justify-between">
+        <div className="h-4 w-28 rounded bg-zinc-700" />
+        <div className="h-4 w-20 rounded bg-zinc-700" />
+      </div>
+      <div className="space-y-3">
+        <div className="h-4 w-full rounded bg-zinc-700" />
+        <div className="h-4 w-4/5 rounded bg-zinc-700" />
+        <div className="h-4 w-2/3 rounded bg-zinc-700" />
+      </div>
+      <div className="mt-4 h-4 w-24 rounded bg-zinc-700" />
+    </div>
+  );
+}

--- a/apps/web/src/components/ProfileCard.tsx
+++ b/apps/web/src/components/ProfileCard.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+export interface Profile {
+  address: string;
+  username?: string;
+  followerCount?: number;
+  follower_count?: number;
+  isFollowing?: boolean;
+}
+
+interface ProfileCardProps {
+  profile: Profile;
+}
+
+function formatAddress(address: string): string {
+  return address.length > 16 ? `${address.slice(0, 6)}...${address.slice(-4)}` : address;
+}
+
+export function ProfileCard({ profile }: ProfileCardProps) {
+  const [following, setFollowing] = useState(!!profile.isFollowing);
+  const followers = profile.followerCount ?? profile.follower_count ?? 0;
+  const displayName = profile.username || formatAddress(profile.address);
+
+  return (
+    <article className="flex items-center gap-4 rounded-lg border border-[var(--border)] bg-[var(--muted)] p-5">
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-violet-900/50 text-lg font-bold text-violet-200">
+        {displayName.slice(0, 1).toUpperCase()}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate font-semibold text-[var(--foreground)]">{displayName}</h2>
+        <p className="truncate text-sm text-[var(--text-muted)]" title={profile.address}>
+          {formatAddress(profile.address)}
+        </p>
+        <p className="text-sm text-[var(--text-muted)]">{followers} followers</p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setFollowing((value) => !value)}
+        className={`shrink-0 rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
+          following
+            ? "border border-[var(--border)] text-[var(--foreground)] hover:border-red-500/60 hover:text-red-300"
+            : "bg-violet-600 text-white hover:bg-violet-500"
+        }`}
+      >
+        {following ? "Following" : "Follow"}
+      </button>
+    </article>
+  );
+}

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -1,38 +1,55 @@
 'use client';
 
-import { useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
+import { validateSearchQuery } from '@/lib/validate';
 
 interface SearchBarProps {
   onSearch: (query: string) => void;
   placeholder?: string;
+  initialValue?: string;
+  className?: string;
+  inputClassName?: string;
+  buttonLabel?: string;
 }
 
-export default function SearchBar({ onSearch, placeholder = "Search posts..." }: SearchBarProps) {
-  const [query, setQuery] = useState('');
+export default function SearchBar({
+  onSearch,
+  placeholder = "Search posts...",
+  initialValue = "",
+  className = "w-full max-w-md",
+  inputClassName = "",
+  buttonLabel = "Search",
+}: SearchBarProps) {
+  const [query, setQuery] = useState(initialValue);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  useEffect(() => {
+    setQuery(initialValue);
+  }, [initialValue]);
+
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    if (query.trim()) {
-      onSearch(query.trim());
-    }
+    const trimmed = query.trim();
+    if (!validateSearchQuery(trimmed).valid) return;
+    onSearch(trimmed);
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-md">
+    <form onSubmit={handleSubmit} className={className} role="search">
       <div className="relative">
         <input
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={placeholder}
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-label={placeholder}
+          className={`w-full rounded-lg border border-[var(--border)] bg-[var(--muted)] px-4 py-2 pr-24 text-[var(--foreground)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-violet-500 ${inputClassName}`}
         />
         <button
           type="submit"
-          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
-          disabled={!query.trim()}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded bg-violet-600 px-3 py-1 text-sm font-semibold text-white hover:bg-violet-500 disabled:opacity-50"
+          disabled={!validateSearchQuery(query).valid}
         >
-          Search
+          {buttonLabel}
         </button>
       </div>
     </form>

--- a/apps/web/tests/e2e/search.spec.ts
+++ b/apps/web/tests/e2e/search.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+test("search renders post and profile results from the NavBar", async ({ page }) => {
+  await page.route("**/api/search?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        posts: [
+          {
+            id: "old-post",
+            author: "GALICE1234567890",
+            content: "A stellar builders update from last month.",
+            tip_total: 2,
+            timestamp: 1_735_689_600,
+          },
+          {
+            id: "new-post",
+            author: "GBOB1234567890",
+            content: "Fresh Stellar launch notes.",
+            tip_total: 50,
+            timestamp: 1_738_368_000,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route("**/api/profiles/search?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        profiles: [
+          {
+            address: "GSTELLARPROFILE1234567890",
+            username: "stellar_alice",
+            followerCount: 12,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/");
+
+  await page.getByRole("search").first().getByRole("textbox").fill("stellar");
+  await page.getByRole("search").first().getByRole("button", { name: "Search" }).click();
+
+  await expect(page).toHaveURL(/\/search\?q=stellar/);
+  await expect(page.getByText("A stellar builders update from last month.")).toBeVisible();
+  await expect(page.locator("mark").filter({ hasText: /stellar/i }).first()).toBeVisible();
+
+  await page.getByLabel("Sort").selectOption("most_tipped");
+  await expect(page).toHaveURL(/sort=most_tipped/);
+  await expect(page.locator("article").first()).toContainText("Fresh Stellar launch notes.");
+
+  await page.getByLabel("From").fill("2025-01-01");
+  await expect(page).toHaveURL(/from=2025-01-01/);
+  await expect(page.getByText("A stellar builders update from last month.")).toBeHidden();
+
+  await page.getByRole("button", { name: "Profiles" }).click();
+  await expect(page).toHaveURL(/tab=profiles/);
+  await expect(page.getByText("stellar_alice")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Follow" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Closes #595

- Added the `/search` page for URL-driven post/profile search.
- Wired the NavBar search form to navigate to `/search?q=:query`.
- Added posts/profiles tabs, sort controls, date filters, highlighted matches, empty states, and loading skeletons.
- Added minimal `PostCard` and `ProfileCard` components for `apps/web`.
- Added a focused Playwright E2E test for the search flow.

## Validation

- `npx pnpm --filter apps-web build`
- `npx pnpm --filter apps-web test:e2e -- tests/e2e/search.spec.ts`

## Notes

- Backend/indexer changes are intentionally out of scope for this web-only issue.
- Manual local search requires an indexer exposing `GET /api/search` and `GET /api/profiles/search`.
- `npx pnpm --filter apps-web exec tsc --noEmit` still fails on an existing React type mismatch in `apps/web/src/components/WalletProvider.tsx`.