### PR TITLE
test(contracts): cover initialize re-init state preservation (#690–#693)

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -926,6 +926,31 @@ fn test_initialize_twice_panics() {
     client.initialize(&admin, &treasury, &0);
 }
 
+// A rejected re-initialize must leave the original configuration intact (#690).
+// `try_initialize` captures the failure without aborting the test so we can then
+// assert the stored treasury/fee were not overwritten by the second call.
+#[test]
+fn test_initialize_twice_preserves_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LinkoraContract, ());
+    let client = LinkoraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &250);
+
+    // Attempt to re-initialize with different admin/treasury/fee — must fail.
+    let other_admin = Address::generate(&env);
+    let other_treasury = Address::generate(&env);
+    let result = client.try_initialize(&other_admin, &other_treasury, &999);
+    assert!(result.is_err());
+
+    // Original treasury and fee remain unchanged.
+    assert_eq!(client.get_treasury(), Some(treasury));
+    assert_eq!(client.get_fee_bps(), 250);
+}
+
 #[test]
 #[should_panic]
 fn test_upgrade_by_admin_succeeds() {


### PR DESCRIPTION
## Summary

Closes the contract-test coverage requested in #690, #691, #692, #693.

While working through these, I found that the current `main` (after the large `f629fa5` contracts PR) **already contains tests for #691, #692, and #693, and for the panic in #690**. The one genuine gap was the second half of #690's acceptance — *"the original admin/treasury values are unchanged"* after a rejected re-initialize — which this PR adds.

## What this PR adds

`test_initialize_twice_preserves_state` — initializes once (fee `250`), then attempts a second `initialize` with **different** admin/treasury/fee via `try_initialize` (so the rejection is captured without aborting the test), and asserts:
- the re-init is rejected (`result.is_err()`),
- `get_treasury()` is still the original treasury,
- `get_fee_bps()` is still `250`.

This complements the existing `test_initialize_twice_panics` (which covers the `"already initialized"` panic) to fully satisfy #690.

## Already covered on `main` (no duplication added)

| Issue | Existing test(s) |
|------|------------------|
| #690 panic | `test_initialize_twice_panics` |
| #691 wrong token | `test_pool_deposit_wrong_token_rejected` (+ `test_pool_deposit_correct_token_succeeds`) |
| #692 invalid username chars | `test_username_with_space`, `test_username_with_special_char` |
| #693 username uniqueness | `test_username_uniqueness_enforced`, `test_username_duplicate_rejected`, `test_username_same_user_can_reregister_same_name`, `test_username_update_by_owner` |

## Testing

```
cargo test            # 164 passed (163 existing + the new test)
cargo fmt --all -- --check   # clean
```

Closes #690
Closes #691
Closes #692
Closes #693