### PR TITLE
feat(web): wallet copy button, 404 page, post stat badges, feed skeleton

### DIFF
--- a/packages/web/app/components/ConnectWallet.tsx
+++ b/packages/web/app/components/ConnectWallet.tsx
@@ -1,15 +1,39 @@
 "use client";
 
-import { useWallet, formatAddress } from "./WalletProvider";
+import { useState } from "react";
+import { useWallet } from "./WalletProvider";
+
+function truncateAddress(address: string): string {
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
 
 export function ConnectWallet() {
   const { isConnected, isConnecting, error, connect, disconnect, publicKey } = useWallet();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!publicKey) return;
+    await navigator.clipboard.writeText(publicKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   if (isConnected && publicKey) {
     return (
       <div style={styles.container}>
         <div style={styles.addressBadge}>
-          <span style={styles.address} data-testid="wallet-address">{formatAddress(publicKey)}</span>
+          <span style={styles.address} data-testid="wallet-address" title={publicKey}>
+            {truncateAddress(publicKey)}
+          </span>
+          <button
+            onClick={handleCopy}
+            style={styles.copyButton}
+            aria-label={copied ? "Address copied" : "Copy wallet address"}
+            title={copied ? "Copied!" : "Copy address"}
+            data-testid="copy-wallet-address"
+          >
+            {copied ? "✓" : "⧉"}
+          </button>
         </div>
         <button onClick={disconnect} style={styles.disconnectButton} data-testid="disconnect-wallet">
           Disconnect
@@ -59,6 +83,9 @@ const styles: Record<string, React.CSSProperties> = {
     minHeight: "var(--min-touch-target)",
   },
   addressBadge: {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--spacing-xs)",
     padding: "var(--spacing-sm) var(--spacing-md)",
     background: "var(--color-bg-secondary)",
     borderRadius: "8px",
@@ -67,6 +94,18 @@ const styles: Record<string, React.CSSProperties> = {
   },
   address: {
     fontWeight: 500,
+  },
+  copyButton: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "transparent",
+    border: "none",
+    cursor: "pointer",
+    fontSize: "0.95rem",
+    lineHeight: 1,
+    padding: "2px",
+    color: "var(--color-text-secondary)",
   },
   error: {
     color: "var(--color-like)",

--- a/packages/web/app/components/Feed.tsx
+++ b/packages/web/app/components/Feed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PostCard, Post } from "./PostCard";
+import { PostCardSkeleton } from "./PostCardSkeleton";
 
 interface FeedProps {
   posts: Post[];
@@ -21,7 +22,7 @@ export function Feed({
     return (
       <div style={styles.container}>
         {[1, 2, 3].map((i) => (
-          <div key={i} style={styles.skeleton}></div>
+          <PostCardSkeleton key={i} />
         ))}
       </div>
     );
@@ -57,13 +58,6 @@ const styles: Record<string, React.CSSProperties> = {
     maxWidth: "600px",
     margin: "0 auto",
     padding: "var(--spacing-md)",
-  },
-  skeleton: {
-    height: "200px",
-    background: "var(--color-bg-secondary)",
-    borderRadius: "12px",
-    marginBottom: "var(--spacing-md)",
-    animation: "pulse 1.5s ease-in-out infinite",
   },
   empty: {
     textAlign: "center",

--- a/packages/web/app/components/PostCard.tsx
+++ b/packages/web/app/components/PostCard.tsx
@@ -72,6 +72,21 @@ export function PostCard({
 
       <div style={styles.content}>{post.content}</div>
 
+      <div style={styles.stats}>
+        <span style={styles.statBadge} data-testid="like-count-badge">
+          <span style={styles.icon} aria-hidden="true">
+            ❤️
+          </span>
+          {likeCount} {likeCount === 1 ? "Like" : "Likes"}
+        </span>
+        <span style={styles.statBadge} data-testid="tip-total-badge">
+          <span style={styles.icon} aria-hidden="true">
+            💎
+          </span>
+          {formatTipTotal(post.tip_total)} XLM tipped
+        </span>
+      </div>
+
       <div style={styles.actions}>
         <button
           onClick={handleLike}
@@ -143,6 +158,24 @@ const styles: Record<string, React.CSSProperties> = {
     lineHeight: 1.6,
     whiteSpace: "pre-wrap",
     wordBreak: "break-word",
+  },
+  stats: {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--spacing-sm)",
+    marginBottom: "var(--spacing-md)",
+    flexWrap: "wrap",
+  },
+  statBadge: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "var(--spacing-xs)",
+    padding: "var(--spacing-xs) var(--spacing-sm)",
+    borderRadius: "999px",
+    background: "var(--color-primary-light)",
+    color: "var(--color-primary)",
+    fontSize: "0.8rem",
+    fontWeight: 600,
   },
   actions: {
     display: "flex",

--- a/packages/web/app/components/PostCardSkeleton.tsx
+++ b/packages/web/app/components/PostCardSkeleton.tsx
@@ -1,0 +1,70 @@
+import type { CSSProperties } from "react";
+
+export function PostCardSkeleton() {
+  return (
+    <article style={styles.card} data-testid="post-card-skeleton">
+      <div style={styles.header}>
+        <div style={styles.avatar} />
+        <div style={styles.meta}>
+          <div style={{ ...styles.line, width: "40%" }} />
+          <div style={{ ...styles.line, height: "10px", width: "25%", marginTop: "6px" }} />
+        </div>
+      </div>
+      <div style={{ ...styles.line, width: "100%", marginTop: "var(--spacing-md)" }} />
+      <div style={{ ...styles.line, width: "82%", marginTop: "var(--spacing-sm)" }} />
+      <div style={styles.footer}>
+        <div style={{ ...styles.chip, width: "72px" }} />
+        <div style={{ ...styles.chip, width: "96px" }} />
+      </div>
+    </article>
+  );
+}
+
+const shimmerBackground =
+  "linear-gradient(90deg, var(--color-bg-secondary) 0%, var(--color-border) 50%, var(--color-bg-secondary) 100%)";
+
+const styles: Record<string, CSSProperties> = {
+  card: {
+    background: "var(--color-bg)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "12px",
+    padding: "var(--spacing-lg)",
+    marginBottom: "var(--spacing-md)",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--spacing-sm)",
+  },
+  avatar: {
+    width: "40px",
+    height: "40px",
+    borderRadius: "50%",
+    flexShrink: 0,
+    background: shimmerBackground,
+    backgroundSize: "200% 100%",
+    animation: "shimmer 1.5s infinite",
+  },
+  meta: {
+    flex: 1,
+  },
+  line: {
+    height: "12px",
+    borderRadius: "9999px",
+    background: shimmerBackground,
+    backgroundSize: "200% 100%",
+    animation: "shimmer 1.5s infinite",
+  },
+  footer: {
+    display: "flex",
+    gap: "var(--spacing-sm)",
+    marginTop: "var(--spacing-md)",
+  },
+  chip: {
+    height: "24px",
+    borderRadius: "9999px",
+    background: shimmerBackground,
+    backgroundSize: "200% 100%",
+    animation: "shimmer 1.5s infinite",
+  },
+};

--- a/packages/web/app/not-found.tsx
+++ b/packages/web/app/not-found.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+
+export default function NotFound() {
+  return (
+    <main style={styles.main}>
+      <div style={styles.card}>
+        <div style={styles.icon} aria-hidden="true">
+          🧭
+        </div>
+        <h1 style={styles.title}>404</h1>
+        <p style={styles.text}>
+          We couldn&apos;t find the page you were looking for. It may have been moved or
+          never existed.
+        </p>
+        <Link href="/feed" style={styles.link}>
+          Back to Feed
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  main: {
+    minHeight: "calc(100vh - 73px)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "var(--spacing-xl)",
+  },
+  card: {
+    maxWidth: "420px",
+    width: "100%",
+    textAlign: "center",
+    background: "var(--color-bg)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "16px",
+    padding: "var(--spacing-xl)",
+  },
+  icon: {
+    fontSize: "3rem",
+    marginBottom: "var(--spacing-md)",
+  },
+  title: {
+    fontSize: "2.5rem",
+    fontWeight: 800,
+    color: "var(--color-primary)",
+    marginBottom: "var(--spacing-sm)",
+    letterSpacing: "-0.03em",
+  },
+  text: {
+    color: "var(--color-text-secondary)",
+    lineHeight: 1.6,
+    marginBottom: "var(--spacing-lg)",
+  },
+  link: {
+    display: "inline-block",
+    padding: "var(--spacing-sm) var(--spacing-xl)",
+    background: "var(--color-primary)",
+    color: "white",
+    borderRadius: "8px",
+    fontWeight: 600,
+    textDecoration: "none",
+    minHeight: "var(--min-touch-target)",
+    lineHeight: "var(--min-touch-target)",
+  },
+};


### PR DESCRIPTION
## Summary

Implements four small web UI improvements:

- **Wallet address copy** — the NavBar wallet badge now shows the connected address truncated to `first4…last4` (e.g. `GABC…XY12`) with a click-to-copy icon button that confirms with a checkmark.
- **404 page** — adds `app/not-found.tsx` with a friendly message and a "Back to Feed" link to `/feed`, styled with the site's existing design tokens (`--color-primary`, `--spacing-*`, etc.) to match the rest of the app.
- **PostCard stat badges** — adds like count and tip total badges below the post content on `PostCard`, distinct from the existing interactive like/tip action buttons.
- **Feed loading skeleton** — replaces the blank/placeholder loading block on the Feed page with a new `PostCardSkeleton` component (shimmer animation, reusing the existing `shimmer` keyframe also used by `PoolCard`), mirroring the mobile app's `SkeletonBase`/`PostCardSkeleton` pattern.

## Test plan

- [ ] `pnpm --filter web dev` and connect a Freighter wallet — confirm the NavBar shows the truncated address and the copy button copies the full address to the clipboard
- [ ] Visit an unknown route (e.g. `/this-does-not-exist`) — confirm the new 404 page renders and the link navigates to `/feed`
- [ ] Open the Feed with posts that have likes/tips — confirm the like count and tip total badges render below the post content
- [ ] Load the Feed page while posts are fetching — confirm `PostCardSkeleton` placeholders render instead of a blank screen

Closes #661
Closes #658
Closes #659
Closes #660