### PR TITLE
feat(web): resolve issues #662 #663 #665 #671

### DIFF
--- a/apps/web/src/app/pools/page.tsx
+++ b/apps/web/src/app/pools/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import PoolCard from '@/components/PoolCard';

--- a/apps/web/src/app/profile/[address]/page.tsx
+++ b/apps/web/src/app/profile/[address]/page.tsx
@@ -13,7 +13,19 @@ import {
 } from "@/lib/LinkoraEventSubscriber";
 import { FollowDrawer } from "@/components/profile/FollowDrawer";
 import { CreatorTokenPanel } from "@/components/profile/CreatorTokenPanel";
-import { LinkoraClient } from "../../../../../../packages/sdk/src/client";
+import {
+  TransactionBuilder,
+  BASE_FEE,
+  Contract,
+  Address,
+  rpc as StellarRpc,
+} from "@stellar/stellar-sdk";
+import { signTransaction } from "@stellar/freighter-api";
+
+const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID || "CDUMMY";
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || "https://soroban-testnet.stellar.org";
+const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Helpers                                                                  */
@@ -46,6 +58,7 @@ export default function ProfilePage() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerType, setDrawerType] = useState<"followers" | "following">("followers");
   const [copyFeedback, setCopyFeedback] = useState(false);
+  const [followLoading, setFollowLoading] = useState(false);
 
   /* ── Optimistic follow state ────────────────────────────────────────── */
 
@@ -78,42 +91,77 @@ export default function ProfilePage() {
   /* ── Follow / unfollow ──────────────────────────────────────────────── */
 
   const handleFollowToggle = useCallback(async () => {
-    if (!currentUserAddress) return;
+    if (!currentUserAddress || followLoading) return;
 
     const key = `${currentUserAddress}:${address}`;
     const newIsFollowing = !followState.isFollowing;
 
-    // Optimistic UI
+    // Optimistic UI update
     OptimisticStore.setFollowState(key, {
       isFollowing: newIsFollowing,
       followersCount: followState.followersCount + (newIsFollowing ? 1 : -1),
       followingCount: followState.followingCount,
     });
 
+    setFollowLoading(true);
+
     try {
-      const client = new LinkoraClient({
-        contractId: process.env.NEXT_PUBLIC_CONTRACT_ID || "CDUMMY",
-        rpcUrl: process.env.NEXT_PUBLIC_RPC_URL || "https://soroban-testnet.stellar.org",
+      const server = new StellarRpc.Server(RPC_URL);
+      const account = await server.getAccount(currentUserAddress);
+
+      const contract = new Contract(CONTRACT_ID);
+      const op = contract.call(
+        newIsFollowing ? "follow" : "unfollow",
+        Address.fromString(currentUserAddress).toScVal(),
+        Address.fromString(address).toScVal()
+      );
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(op)
+        .setTimeout(30)
+        .build();
+
+      const simulated = await server.simulateTransaction(tx);
+      if (StellarRpc.Api.isSimulationError(simulated)) {
+        throw new Error(`Simulation failed: ${simulated.error}`);
+      }
+
+      const finalTx = StellarRpc.assembleTransaction(tx, simulated).build();
+      const xdrString = finalTx.toXDR();
+
+      const signedXdr = await signTransaction(xdrString, {
+        networkPassphrase: NETWORK_PASSPHRASE,
       });
 
-      // These methods return transaction XDR envelopes.
-      // In production, this XDR would be signed via Freighter and submitted.
-      const _txXdr = newIsFollowing
-        ? client.follow(currentUserAddress, address)
-        : client.unfollow(currentUserAddress, address);
+      const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+      const sendResponse = await server.sendTransaction(signedTx);
 
-      // TODO: sign & submit via Freighter — same pattern as mobile's FollowButton.
-      // For now we treat the optimistic update as the final state.
+      if (sendResponse.status === "ERROR") {
+        throw new Error("Transaction failed to submit");
+      }
+
+      let status: string = sendResponse.status;
+      const startTime = Date.now();
+      while (status === "PENDING" && Date.now() - startTime < 30000) {
+        await new Promise((r) => setTimeout(r, 1000));
+        const txResponse = await server.getTransaction(sendResponse.hash);
+        status = txResponse.status as string;
+      }
     } catch (error) {
       console.error("Follow/unfollow failed:", error);
-      // Rollback
+      // Rollback optimistic update
       OptimisticStore.setFollowState(key, {
         isFollowing: !newIsFollowing,
         followersCount: followState.followersCount,
         followingCount: followState.followingCount,
       });
+    } finally {
+      setFollowLoading(false);
     }
-  }, [currentUserAddress, address, followState]);
+  }, [currentUserAddress, address, followState, followLoading]);
 
   /* ── Copy address ───────────────────────────────────────────────────── */
 
@@ -262,18 +310,21 @@ export default function ProfilePage() {
               <button
                 onClick={handleFollowToggle}
                 id="follow-btn"
-                className={`px-6 py-2 rounded-full font-bold transition-all ${
+                disabled={followLoading}
+                className={`px-6 py-2 rounded-full font-bold transition-all disabled:opacity-60 disabled:cursor-not-allowed ${
                   followState.isFollowing
                     ? "bg-transparent border border-[var(--text-muted)] text-[var(--text-primary)] hover:bg-[var(--error)] hover:border-[var(--error)] hover:text-white"
                     : "bg-[var(--accent-coral)] text-white hover:opacity-90"
                 }`}
                 aria-label={
-                  followState.isFollowing
-                    ? `Unfollow ${profile.username}`
-                    : `Follow ${profile.username}`
+                  followLoading
+                    ? "Updating follow status..."
+                    : followState.isFollowing
+                      ? `Unfollow ${profile.username}`
+                      : `Follow ${profile.username}`
                 }
               >
-                {followState.isFollowing ? "Following" : "Follow"}
+                {followLoading ? "Updating..." : followState.isFollowing ? "Following" : "Follow"}
               </button>
             )}
           </div>

--- a/apps/web/src/components/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+
+interface PoolCardProps {
+  poolId: string;
+  token: string;
+  balance: bigint | number | string;
+  adminCount: number;
+  threshold: number;
+}
+
+export default function PoolCard({ poolId, token, balance, adminCount, threshold }: PoolCardProps) {
+  const formattedBalance = (Number(balance) / 1e7).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 7,
+  });
+
+  return (
+    <div className="bg-neutral-800 border border-neutral-700 rounded-2xl p-5 hover:border-neutral-500 transition-colors cursor-pointer shadow-md">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-bold text-white truncate" title={poolId}>
+            {poolId}
+          </h3>
+          <span className="text-sm text-neutral-400 font-mono">{token}</span>
+        </div>
+        {/* M-of-N threshold badge */}
+        <span
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-indigo-500/20 border border-indigo-500/40 text-indigo-300 text-xs font-semibold whitespace-nowrap flex-shrink-0"
+          title={`Requires ${threshold} of ${adminCount} admin signatures`}
+        >
+          {threshold} of {adminCount} admins
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-neutral-400 border-t border-neutral-700 pt-4">
+        <span>Balance</span>
+        <span className="font-semibold text-white">
+          {formattedBalance} {token}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PostComposeModal.test.tsx
+++ b/apps/web/src/components/PostComposeModal.test.tsx
@@ -98,20 +98,34 @@ describe("PostComposeModal", () => {
     renderModal(true);
     expect(screen.getByText("Compose Post")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("What's happening on-chain?")).toBeInTheDocument();
-    expect(screen.getByText("0 / 280")).toBeInTheDocument();
+    expect(screen.getByText("280")).toBeInTheDocument();
     expect(screen.getByText("Publish Post")).toBeInTheDocument();
   });
 
-  // 3. Character counter updates on input
-  it("updates character counter as user types", () => {
+  // 3. Character counter shows remaining chars and turns amber/red at thresholds
+  it("updates remaining character counter as user types", () => {
     renderModal(true);
     const textarea = screen.getByPlaceholderText("What's happening on-chain?");
 
+    // "Hello world" = 11 chars → 280 - 11 = 269 remaining
     fireEvent.change(textarea, { target: { value: "Hello world" } });
-    expect(screen.getByText("11 / 280")).toBeInTheDocument();
+    expect(screen.getByText("269")).toBeInTheDocument();
 
+    // "Hello linkora community" = 23 chars → 280 - 23 = 257 remaining
     fireEvent.change(textarea, { target: { value: "Hello linkora community" } });
-    expect(screen.getByText("23 / 280")).toBeInTheDocument();
+    expect(screen.getByText("257")).toBeInTheDocument();
+
+    // 230 chars → 50 remaining (amber threshold)
+    const amberContent = "a".repeat(230);
+    fireEvent.change(textarea, { target: { value: amberContent } });
+    const counterAmber = screen.getByLabelText("50 characters remaining");
+    expect(counterAmber).toHaveClass("text-yellow-500");
+
+    // 270 chars → 10 remaining (red threshold)
+    const redContent = "a".repeat(270);
+    fireEvent.change(textarea, { target: { value: redContent } });
+    const counterRed = screen.getByLabelText("10 characters remaining");
+    expect(counterRed).toHaveClass("text-red-500");
   });
 
   // 4. Submit disabled when empty
@@ -178,6 +192,10 @@ describe("PostComposeModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Post published successfully! Redirecting...")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /view on stellar expert/i })).toHaveAttribute(
+        "href",
+        "https://stellar.expert/explorer/testnet/tx/tx-hash-123"
+      );
     });
 
     jest.advanceTimersByTime(2000);

--- a/apps/web/src/components/PostComposeModal.tsx
+++ b/apps/web/src/components/PostComposeModal.tsx
@@ -15,7 +15,8 @@ import {
 import { signTransaction } from "@stellar/freighter-api";
 
 const MAX_CONTENT_LENGTH = 280;
-const WARNING_THRESHOLD = 260;
+const AMBER_THRESHOLD = 50;
+const RED_THRESHOLD = 10;
 
 const RPC_URL = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
 const NETWORK_PASSPHRASE =
@@ -35,6 +36,7 @@ interface PublishState {
   status: SubmitStatus;
   errorMsg: string;
   postId: string | null;
+  txHash: string | null;
 }
 
 export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModalProps) {
@@ -45,11 +47,14 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
     status: "idle",
     errorMsg: "",
     postId: null,
+    txHash: null,
   });
 
   const charCount = content.length;
-  const isNearLimit = charCount >= WARNING_THRESHOLD && charCount <= MAX_CONTENT_LENGTH;
+  const remaining = MAX_CONTENT_LENGTH - charCount;
   const isOverLimit = charCount > MAX_CONTENT_LENGTH;
+  const isRed = remaining <= RED_THRESHOLD;
+  const isAmber = !isRed && remaining <= AMBER_THRESHOLD;
   const isEmpty = content.trim().length === 0;
   const isDisabled = isEmpty || isOverLimit || publishState.status !== "idle";
 
@@ -148,6 +153,7 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
           status: "success",
           errorMsg: "",
           postId: newPostId,
+          txHash: sendResponse.hash,
         });
 
         setTimeout(() => {
@@ -160,6 +166,7 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
           status: "error",
           errorMsg: message,
           postId: null,
+          txHash: null,
         });
       }
     },
@@ -167,7 +174,7 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
   );
 
   const handleTryAgain = () => {
-    setPublishState({ status: "idle", errorMsg: "", postId: null });
+    setPublishState({ status: "idle", errorMsg: "", postId: null, txHash: null });
   };
 
   if (!isOpen) return null;
@@ -217,9 +224,10 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
             {/* Character counter */}
             <div className="absolute bottom-3 right-4 flex items-center gap-2">
               <span
-                className={`text-xs font-mono ${isOverLimit ? "text-red-500" : isNearLimit ? "text-yellow-500" : "text-[var(--text-muted)]"}`}
+                className={`text-xs font-mono ${isRed ? "text-red-500" : isAmber ? "text-yellow-500" : "text-[var(--text-muted)]"}`}
+                aria-label={`${remaining} characters remaining`}
               >
-                {charCount} / {MAX_CONTENT_LENGTH}
+                {remaining}
               </span>
             </div>
           </div>
@@ -250,9 +258,21 @@ export function PostComposeModal({ isOpen, onClose, publicKey }: PostComposeModa
           )}
 
           {publishState.status === "success" && (
-            <div className="bg-green-500/10 border border-green-500/20 text-green-500 rounded-xl p-3 text-sm flex items-center gap-2">
-              <span>✅</span>
-              <span>Post published successfully! Redirecting...</span>
+            <div className="bg-green-500/10 border border-green-500/20 text-green-500 rounded-xl p-3 text-sm flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span>✅</span>
+                <span>Post published successfully! Redirecting...</span>
+              </div>
+              {publishState.txHash && (
+                <a
+                  href={`https://stellar.expert/explorer/testnet/tx/${publishState.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green-400 underline text-xs self-start hover:text-green-300 transition-colors"
+                >
+                  View on Stellar Expert ↗
+                </a>
+              )}
             </div>
           )}
 

--- a/apps/web/src/lib/OptimisticStore.ts
+++ b/apps/web/src/lib/OptimisticStore.ts
@@ -12,12 +12,25 @@ export type FollowState = {
   followingCount: number;
 };
 
+export type LikeState = {
+  isLiked: boolean;
+  likeCount: number;
+};
+
+export type TipState = {
+  tipTotal: number;
+};
+
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Store internals                                                          */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 // Key format: `${followerAddress}:${followeeAddress}`
 const followStateMap = new Map<string, FollowState>();
+// Key format: `${userAddress}:${postId}`
+const likeStateMap = new Map<string, LikeState>();
+// Key format: postId string
+const tipStateMap = new Map<string, TipState>();
 const listeners = new Set<() => void>();
 
 function subscribe(listener: () => void) {
@@ -37,6 +50,9 @@ function notify() {
 /*  Public API                                                               */
 /* ────────────────────────────────────────────────────────────────────────── */
 
+const pendingMap = new Map<string, boolean>();
+const legacyFollowingMap = new Map<string, boolean>();
+
 export const OptimisticStore = {
   setFollowState(key: string, state: FollowState) {
     followStateMap.set(key, state);
@@ -51,19 +67,50 @@ export const OptimisticStore = {
     followStateMap.delete(key);
     notify();
   },
+
+  setLikeState(key: string, state: LikeState) {
+    likeStateMap.set(key, state);
+    notify();
+  },
+
+  getLikeState(key: string): LikeState | undefined {
+    return likeStateMap.get(key);
+  },
+
+  setTipState(key: string, state: TipState) {
+    tipStateMap.set(key, state);
+    notify();
+  },
+
+  getTipState(key: string): TipState | undefined {
+    return tipStateMap.get(key);
+  },
+
+  // Legacy API for FollowList.tsx
+  subscribe,
+  isFollowing(targetAddress: string): boolean {
+    return legacyFollowingMap.get(targetAddress) ?? false;
+  },
+  setFollowing(targetAddress: string, isFollowing: boolean) {
+    legacyFollowingMap.set(targetAddress, isFollowing);
+    notify();
+  },
+  isPending(targetAddress: string): boolean {
+    return pendingMap.get(targetAddress) ?? false;
+  },
+  setPending(targetAddress: string, isPending: boolean) {
+    pendingMap.set(targetAddress, isPending);
+    notify();
+  },
 };
 
 /* ────────────────────────────────────────────────────────────────────────── */
-/*  Hook                                                                     */
+/*  Hooks                                                                    */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 /**
  * Returns the optimistic follow state if one exists, otherwise falls back
  * to `initialState` (the "truth" from the server/contract).
- *
- * @param follower  Current user's address (null when not connected)
- * @param followee  Target profile's address
- * @param initialState  Server-sourced truth state
  */
 export function useOptimisticFollow(
   follower: string | null,
@@ -74,9 +121,46 @@ export function useOptimisticFollow(
 
   const optimistic = useSyncExternalStore(
     subscribe,
-    // Client snapshot
     () => (follower ? OptimisticStore.getFollowState(key) : undefined),
-    // Server snapshot — always undefined (no optimistic state on SSR)
+    () => undefined
+  );
+
+  return optimistic ?? initialState;
+}
+
+/**
+ * Returns the optimistic like state if one exists, otherwise falls back
+ * to `initialState`.
+ */
+export function useOptimisticLike(
+  user: string | null,
+  postId: string | bigint,
+  initialState: LikeState
+): LikeState {
+  const key = `${user}:${postId}`;
+
+  const optimistic = useSyncExternalStore(
+    subscribe,
+    () => (user ? OptimisticStore.getLikeState(key) : undefined),
+    () => undefined
+  );
+
+  return optimistic ?? initialState;
+}
+
+/**
+ * Returns the optimistic tip state if one exists, otherwise falls back
+ * to `initialState`.
+ */
+export function useOptimisticTip(
+  postId: string | bigint,
+  initialState: TipState
+): TipState {
+  const key = String(postId);
+
+  const optimistic = useSyncExternalStore(
+    subscribe,
+    () => OptimisticStore.getTipState(key),
     () => undefined
   );
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,32 @@
+const INDEXER_URL =
+  process.env.NEXT_PUBLIC_INDEXER_URL || "http://localhost:3001";
+
+export interface PoolData {
+  id: string;
+  token: string;
+  balance: bigint;
+  adminCount: number;
+  threshold: number;
+}
+
+/**
+ * Fetch all pools from the indexer.
+ * Falls back to an empty array when the indexer is unreachable.
+ */
+export async function fetchPools(): Promise<PoolData[]> {
+  try {
+    const res = await fetch(`${INDEXER_URL}/api/pools`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    const list = Array.isArray(data) ? data : data.pools ?? [];
+    return list.map((p: any) => ({
+      id: p.pool_id ?? p.id,
+      token: p.token,
+      balance: BigInt(p.balance ?? 0),
+      adminCount: Array.isArray(p.admins) ? p.admins.length : (p.admin_count ?? 0),
+      threshold: p.threshold ?? 1,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/lib/optimisticStore.ts
+++ b/apps/web/src/lib/optimisticStore.ts
@@ -12,12 +12,25 @@ export type FollowState = {
   followingCount: number;
 };
 
+export type LikeState = {
+  isLiked: boolean;
+  likeCount: number;
+};
+
+export type TipState = {
+  tipTotal: number;
+};
+
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Store internals                                                          */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 // Key format: `${followerAddress}:${followeeAddress}`
 const followStateMap = new Map<string, FollowState>();
+// Key format: `${userAddress}:${postId}`
+const likeStateMap = new Map<string, LikeState>();
+// Key format: postId string
+const tipStateMap = new Map<string, TipState>();
 const listeners = new Set<() => void>();
 
 function subscribe(listener: () => void) {
@@ -55,6 +68,24 @@ export const OptimisticStore = {
     notify();
   },
 
+  setLikeState(key: string, state: LikeState) {
+    likeStateMap.set(key, state);
+    notify();
+  },
+
+  getLikeState(key: string): LikeState | undefined {
+    return likeStateMap.get(key);
+  },
+
+  setTipState(key: string, state: TipState) {
+    tipStateMap.set(key, state);
+    notify();
+  },
+
+  getTipState(key: string): TipState | undefined {
+    return tipStateMap.get(key);
+  },
+
   // Legacy API for FollowList.tsx
   subscribe,
   isFollowing(targetAddress: string): boolean {
@@ -74,16 +105,12 @@ export const OptimisticStore = {
 };
 
 /* ────────────────────────────────────────────────────────────────────────── */
-/*  Hook                                                                     */
+/*  Hooks                                                                    */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 /**
  * Returns the optimistic follow state if one exists, otherwise falls back
  * to `initialState` (the "truth" from the server/contract).
- *
- * @param follower  Current user's address (null when not connected)
- * @param followee  Target profile's address
- * @param initialState  Server-sourced truth state
  */
 export function useOptimisticFollow(
   follower: string | null,
@@ -94,9 +121,46 @@ export function useOptimisticFollow(
 
   const optimistic = useSyncExternalStore(
     subscribe,
-    // Client snapshot
     () => (follower ? OptimisticStore.getFollowState(key) : undefined),
-    // Server snapshot — always undefined (no optimistic state on SSR)
+    () => undefined
+  );
+
+  return optimistic ?? initialState;
+}
+
+/**
+ * Returns the optimistic like state if one exists, otherwise falls back
+ * to `initialState`.
+ */
+export function useOptimisticLike(
+  user: string | null,
+  postId: string | bigint,
+  initialState: LikeState
+): LikeState {
+  const key = `${user}:${postId}`;
+
+  const optimistic = useSyncExternalStore(
+    subscribe,
+    () => (user ? OptimisticStore.getLikeState(key) : undefined),
+    () => undefined
+  );
+
+  return optimistic ?? initialState;
+}
+
+/**
+ * Returns the optimistic tip state if one exists, otherwise falls back
+ * to `initialState`.
+ */
+export function useOptimisticTip(
+  postId: string | bigint,
+  initialState: TipState
+): TipState {
+  const key = String(postId);
+
+  const optimistic = useSyncExternalStore(
+    subscribe,
+    () => OptimisticStore.getTipState(key),
     () => undefined
   );
 


### PR DESCRIPTION
  ## Summary

  Resolves four open issues in the web app with minimal, targeted changes.

  ## Changes

  ### #663 — Character count remaining in Compose Post modal
  - Changed the in-textarea counter from `typed / 280` to **remaining** (`280 - typed`)
  - Amber colour at ≤ 50 remaining; red at ≤ 10 remaining
  - Updated `PostComposeModal.test.tsx` to assert the new format and colour thresholds

  ### #671 — Stellar Expert transaction link in success toast
  - Added `txHash` field to `PublishState`
  - Success toast now renders a `View on Stellar Expert ↗` link pointing to
    `https://stellar.expert/explorer/testnet/tx/{hash}`
  - Test updated to assert the link and its `href`

  ### #662 — Wire Follow/Unfollow button on Profile page to Freighter
  - Replaced the TODO stub in `handleFollowToggle` with a full Freighter signing flow:
    `getAccount` → build → simulate → `assembleTransaction` → `signTransaction` → submit → poll
  - Added `followLoading` state; button shows `"Updating…"` and is disabled while signing
  - Optimistic follower-count update is rolled back on failure

  ### #665 — Pool admin threshold badge on Pool card
  - Created `apps/web/src/components/PoolCard.tsx` — new web component displaying pool id,
    token, balance, and an **M of N admins** badge (indigo pill) from `threshold` / `adminCount` props
  - Created `apps/web/src/lib/api.ts` with `fetchPools()` that hits the indexer `/api/pools`
  - Added missing `"use client"` directive to the pools page (it uses React hooks)

  ### `OptimisticStore` housekeeping
  - Added `LikeState`, `TipState` types and the matching `setLikeState` / `getTipState` /
    `useOptimisticLike` / `useOptimisticTip` exports so the feed page compiles
  - Included the pre-existing legacy-API additions (`subscribe`, `isFollowing`, `setFollowing`,
    `isPending`, `setPending`) needed by `FollowList.tsx`

  ## Test plan
  - [ ] Open Compose Post modal, type text — counter shows remaining chars, turns amber at 50 left,
        red at 10 left; submit is disabled when empty
  - [ ] Publish a post successfully — success toast shows "View on Stellar Expert ↗" with correct URL
  - [ ] Visit a profile page while connected as a different user — Follow button shows "Updating…"
        while Freighter signs; follower count updates optimistically and rolls back on error
  - [ ] Open `/pools` — each card shows pool name, token, balance, and "M of N admins" badge
  - [ ] Run `pnpm test --filter apps-web` — PostComposeModal tests pass

  Closes #662
  Closes #663
  Closes #665
  Closes #671