### PR TITLE
test(contracts): verify pool_withdraw requires minimum threshold signers

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -1760,6 +1760,30 @@ fn test_pool_withdraw_m_of_n_exceeds_balance_rejected() {
     client.pool_withdraw(&signers, &pool_id, &101, &recipient);
 }
 
+// ── Issue #713: pool_withdraw requires minimum threshold signers ──────────────
+
+#[test]
+#[should_panic(expected = "insufficient signers")]
+fn test_pool_withdraw_requires_minimum_threshold_signers() {
+    // Create a pool with 3 admins and threshold 2.
+    // Call pool_withdraw with only 1 signer.
+    // Verify it panics with 'insufficient signers'.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, pool_id, token, admins) = setup_pool(&env, 3, 2, 300);
+
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &500);
+    client.pool_deposit(&depositor, &pool_id, &token, &100);
+
+    let recipient = Address::generate(&env);
+
+    // Only 1 signer provided, but threshold is 2 — must panic with "insufficient signers"
+    let signers = vec![&env, admins.get(0).unwrap()];
+    client.pool_withdraw(&signers, &pool_id, &50, &recipient);
+}
+
 // ── Issue #343: full tip flow integration tests ───────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the test scenario requested in issue #713.

### What this adds

A new test `test_pool_withdraw_requires_minimum_threshold_signers` in `packages/contracts/contracts/linkora-contracts/src/test.rs` that:

1. Creates a pool with **3 admins** and a **2-of-3 withdrawal threshold** using the existing `setup_pool` helper
2. Calls `pool_withdraw` with only **1 signer**
3. Verifies the contract panics with `'insufficient signers'`

### Why this is distinct from existing tests

The existing `test_pool_withdraw_insufficient_signers` test covers a 2-admin pool with threshold 2 (i.e. 1-of-2 fails). This new test specifically exercises the case where a pool has **more admins than the threshold** (3 admins, threshold 2), confirming the signer count guard fires correctly in that configuration — a separate and meaningful code path.

### Test output

```
running 1 test
test test::test_pool_withdraw_requires_minimum_threshold_signers - should panic ... ok
test result: ok. 1 passed; 0 failed
```

Closes #713