### PR TITLE
feat(indexer): handle pool events in domain processor

### DIFF
--- a/services/indexer/src/__tests__/domain-processor.test.ts
+++ b/services/indexer/src/__tests__/domain-processor.test.ts
@@ -179,6 +179,79 @@ describe("domain-processor: post_deleted", () => {
   });
 });
 
+// ── pool events ───────────────────────────────────────────────────────────────────
+
+describe("domain-processor: pool_created", () => {
+  it("calls db.insertPool with mapped fields", async () => {
+    const db = makeDb();
+    const processor = createDomainProcessor(makePool(), makeNotificationService(), db);
+    const client = makePgClient();
+
+    await processor(
+      client,
+      makeIngestEvent("pool_created", {
+        pool_id: "P123",
+        token: "TOKEN_A",
+        admins: ["A1", "A2"],
+        threshold: 2,
+      })
+    );
+
+    expect(db.insertPool).toHaveBeenCalledWith({
+      pool_id: "P123",
+      token: "TOKEN_A",
+      balance: 0n,
+      admins: ["A1", "A2"],
+      threshold: 2,
+      created_ledger: 100,
+      updated_ledger: 100,
+    });
+  });
+
+  it("does nothing when db is not provided", async () => {
+    const processor = createDomainProcessor(makePool(), makeNotificationService());
+    await expect(
+      processor(makePgClient(), makeIngestEvent("pool_created", { pool_id: "P1" }))
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("domain-processor: pool_deposit", () => {
+  it("calls db.adjustPoolBalance with amount", async () => {
+    const db = makeDb();
+    const processor = createDomainProcessor(makePool(), makeNotificationService(), db);
+    const client = makePgClient();
+
+    await processor(
+      client,
+      makeIngestEvent("pool_deposit", {
+        pool_id: "P123",
+        amount: 500n,
+      })
+    );
+
+    expect(db.adjustPoolBalance).toHaveBeenCalledWith("P123", 500n, 100);
+  });
+});
+
+describe("domain-processor: pool_withdraw", () => {
+  it("calls db.adjustPoolBalance with negative amount", async () => {
+    const db = makeDb();
+    const processor = createDomainProcessor(makePool(), makeNotificationService(), db);
+    const client = makePgClient();
+
+    await processor(
+      client,
+      makeIngestEvent("pool_withdraw", {
+        pool_id: "P123",
+        amount: 200n,
+      })
+    );
+
+    expect(db.adjustPoolBalance).toHaveBeenCalledWith("P123", -200n, 100);
+  });
+});
+
 // ── unknown topics still fall through ────────────────────────────────────────
 
 describe("domain-processor: unknown topic", () => {

--- a/services/indexer/src/domain-processor.ts
+++ b/services/indexer/src/domain-processor.ts
@@ -27,6 +27,11 @@ import {
 } from "./handlers/moderation";
 import { handleBlock, handleUnblock, handleDmKeyPublished } from "./handlers/user";
 import { handleProfileSet } from "./handlers/profile";
+import {
+  handlePoolCreated,
+  handlePoolDeposit,
+  handlePoolWithdraw,
+} from "./handlers/pool";
 import { Database } from "./db";
 import { dispatchNotificationForBusEvent } from "./notifications/events";
 import { scValToNative, xdr } from "@stellar/stellar-sdk";
@@ -396,6 +401,55 @@ export function createDomainProcessor(
         const postId = asBigInt(data.post_id ?? data.id);
 
         await db.markPostDeleted(postId, event.ledgerSequence);
+        break;
+      }
+
+      case "pool_created": {
+        if (!db) break;
+        const pool_id = asString(data.pool_id);
+        const token = asString(data.token);
+        const admins = Array.isArray(data.admins) ? data.admins.map(asString) : [];
+        const threshold = Number(data.threshold) || 1;
+
+        await handlePoolCreated(db, {
+          pool_id,
+          token,
+          admins,
+          threshold,
+          ledger: event.ledgerSequence,
+        });
+        break;
+      }
+
+      case "pool_deposit": {
+        if (!db) break;
+        const pool_id = asString(data.pool_id);
+        const depositor = asString(data.depositor ?? data.user ?? data.from);
+        const token = asString(data.token);
+        const amount = asBigInt(data.amount);
+
+        await handlePoolDeposit(db, {
+          pool_id,
+          depositor,
+          token,
+          amount,
+          ledger: event.ledgerSequence,
+        });
+        break;
+      }
+
+      case "pool_withdraw": {
+        if (!db) break;
+        const pool_id = asString(data.pool_id);
+        const recipient = asString(data.recipient ?? data.user ?? data.to);
+        const amount = asBigInt(data.amount);
+
+        await handlePoolWithdraw(db, {
+          pool_id,
+          recipient,
+          amount,
+          ledger: event.ledgerSequence,
+        });
         break;
       }
 


### PR DESCRIPTION
**Description:**
This PR adds support for processing pool events that were previously being silently dropped by the domain processor. It correctly routes the pool events to the corresponding database handlers and includes complete test coverage.

**Changes Included:**
- Added event handlers for `pool_created`, `pool_deposit`, and `pool_withdraw` in `services/indexer/src/domain-processor.ts`.
- Wired up the respective database calls (`insertPool` and `adjustPoolBalance`) utilizing the handlers in `handlers/pool.ts`.
- Implemented handler tests in `services/indexer/src/__tests__/domain-processor.test.ts` to ensure the pool balance remains consistent and the processor correctly invokes the database methods.

Closes #633