### PR TITLE
feat(mobile): add empty states, error message, and username truncation

### DIFF
--- a/apps/mobile/app/(tabs)/feed.tsx
+++ b/apps/mobile/app/(tabs)/feed.tsx
@@ -58,7 +58,7 @@ export default function FeedScreen() {
   }
 
   if (error && posts.length === 0) {
-    return <ErrorState message={error} onRetry={refresh} />;
+    return <ErrorState message="Could not load posts" onRetry={refresh} />;
   }
 
   return (

--- a/apps/mobile/app/profile/[address].tsx
+++ b/apps/mobile/app/profile/[address].tsx
@@ -9,6 +9,7 @@ import { useWallet } from "../../hooks/useWallet";
 import ProfileHeader from "../../components/ProfileHeader";
 import { PostCard } from "../../components/PostCard";
 import { AnalyticsCard } from "../../components/AnalyticsCard";
+import { EmptyState } from "../../components/states/EmptyState";
 
 type ProfileParams = {
   address: string;
@@ -76,12 +77,9 @@ export default function ProfileDetailScreen() {
         }}
         refreshing={postsLoading}
         contentContainerStyle={styles.list}
-        ListEmptyComponent={() => (
-          <View style={styles.empty}>
-            <Text style={styles.emptyTitle}>No posts yet</Text>
-            <Text style={styles.emptyText}>This user hasn't posted anything.</Text>
-          </View>
-        )}
+        ListEmptyComponent={
+          <EmptyState icon="📭" title="No posts yet" subtitle="This user hasn't posted anything." />
+        }
       />
     </View>
   );
@@ -117,18 +115,6 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
       paddingBottom: 48,
       backgroundColor: theme.colors.surface.background,
     },
-    empty: {
-      padding: 24,
-      alignItems: "center",
-    },
-    emptyTitle: {
-      color: theme.colors.text.primary,
-      fontSize: 16,
-      fontWeight: "700",
-    },
-    emptyText: {
-      color: theme.colors.text.secondary,
-      marginTop: 8,
-    },
+
   });
 }

--- a/apps/mobile/components/ProfileRow.tsx
+++ b/apps/mobile/components/ProfileRow.tsx
@@ -35,7 +35,7 @@ export function ProfileRow({ profile, onPress }: ProfileRowProps) {
         <Text style={styles.avatarText}>{profile.username.charAt(0).toUpperCase()}</Text>
       </View>
       <View style={styles.content}>
-        <Text style={styles.title}>{profile.username}</Text>
+        <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">{profile.username}</Text>
         <Text style={styles.subtitle}>{profile.bio}</Text>
         <Text style={styles.meta}>{shortAddress(profile.address)}</Text>
       </View>


### PR DESCRIPTION
Closes #731
Closes #732
Closes #733
Closes #734

## Changes

### #731 - Show 'No posts yet' empty state on Profile post list
Replaced inline `<View>`/`<Text>` ListEmptyComponent with the reusable `EmptyState` component in `app/profile/[address].tsx`.

### #732 - Add error state to Feed tab when indexer is unreachable
Changed the Feed tab to show a static 'Could not load posts' error message instead of the dynamic hook message.

### #733 - Truncate long usernames in ProfileRow with ellipsis
Added `numberOfLines={1}` and `ellipsizeMode="tail"` to the username `<Text>` in `components/ProfileRow.tsx` to prevent layout overflow.

### #734 - KeyboardAvoidingView in Compose Post screen
Already implemented — `app/post/new.tsx` wraps the text input with `KeyboardAvoidingView` with platform-appropriate behavior.
