### PR TITLE
test(contracts): verify username length constraints on set_profile

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/tests/set_profile_tests.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/tests/set_profile_tests.rs
@@ -1,0 +1,34 @@
+//! Unit tests for `set_profile` username length validation.
+
+#[cfg(test)]
+mod set_profile_tests {
+    use super::*;
+    use soroban_sdk::{Address, Env, String};
+
+    #[test]
+    #[should_panic(expected = "username too short")]
+    fn test_set_profile_username_too_short_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _, _) = setup_contract(&env);
+
+        let user = Address::generate(&env);
+        let token = Address::generate(&env);
+        // 2-character username should panic
+        client.set_profile(&user, &String::from_str(&env, "ab"), &token);
+    }
+
+    #[test]
+    fn test_set_profile_username_minimum_length_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _, _) = setup_contract(&env);
+
+        let user = Address::generate(&env);
+        let token = Address::generate(&env);
+        // 3-character username should succeed
+        client.set_profile(&user, &String::from_str(&env, "abc"), &token);
+        let profile = client.get_profile(&user).unwrap();
+        assert_eq!(profile.username, String::from_str(&env, "abc"));
+    }
+}


### PR DESCRIPTION
closes #720 

## Description
This PR adds targeted smart contract unit tests to assert and lock down the minimum boundary constraints for user profiles. It explicitly verifies that the state-machine rejects invalid short handles while allowing the exact lower bound threshold.

## Changes
* 🧪 **Edge-Case Validation:** Added a panic-testing harness verifying that `set_profile` rejects a 2-character input with the string message `"username too short"`.
* 🟢 **Success-Path Verification:** Added a valid baseline test ensuring a 3-character input successfully clears validation rules and mutates state.

## Acceptance Criteria Verification
* [x] Call `set_profile` with 2 characters -> panics with `'username too short'`.
* [x] Call `set_profile` with 3 characters -> successfully executes.
* [x] Local contract test suite compiles and runs cleanly.

## How to Test
Execute the contract test suite locally:
```bash
cargo test set_profile