### PR TITLE
feat(sdk): add ambient type declarations for optional Ledger peer dependencies

### DIFF
--- a/packages/sdk/src/types/ledger-modules.d.ts
+++ b/packages/sdk/src/types/ledger-modules.d.ts
@@ -1,0 +1,87 @@
+/**
+ * Ambient module declarations for optional Ledger peer dependencies.
+ *
+ * These packages are listed as optional peerDependencies in package.json.
+ * They are loaded at runtime via dynamic import() inside ledger.ts, so they
+ * are never required at install time. However, TypeScript still resolves
+ * module specifiers at compile time and raises TS2307 ("Cannot find module")
+ * when the packages are absent (e.g. in CI environments without libusb /
+ * node-gyp build tools).
+ *
+ * Declaring the modules here gives TypeScript enough type information to
+ * compile cleanly without the native packages being installed. The shapes
+ * reflect exactly what ledger.ts consumes — nothing more.
+ *
+ * Location: packages/sdk/src/types/ledger-modules.d.ts
+ */
+
+// ---------------------------------------------------------------------------
+// @ledgerhq/hw-transport-webhid
+// Browser transport over the WebHID API.
+// ledger.ts usage: TransportWebHID.create() → LedgerTransport
+// ---------------------------------------------------------------------------
+declare module "@ledgerhq/hw-transport-webhid" {
+  interface Transport {
+    close(): Promise<void>;
+  }
+
+  interface TransportWebHIDConstructor {
+    create(): Promise<Transport>;
+  }
+
+  const TransportWebHID: TransportWebHIDConstructor;
+  export default TransportWebHID;
+}
+
+// ---------------------------------------------------------------------------
+// @ledgerhq/hw-transport-node-hid
+// Node.js transport over the native USB HID layer (requires libusb + node-gyp).
+// ledger.ts usage: TransportNodeHID.list() → unknown[], .open(device) → LedgerTransport
+// ---------------------------------------------------------------------------
+declare module "@ledgerhq/hw-transport-node-hid" {
+  interface Transport {
+    close(): Promise<void>;
+  }
+
+  interface TransportNodeHIDConstructor {
+    list(): Promise<unknown[]>;
+    open(device: unknown): Promise<Transport>;
+  }
+
+  const TransportNodeHID: TransportNodeHIDConstructor;
+  export default TransportNodeHID;
+}
+
+// ---------------------------------------------------------------------------
+// @ledgerhq/hw-app-str
+// Stellar application bindings for a Ledger transport.
+// ledger.ts usage:
+//   new StrApp(transport)
+//   app.getPublicKey(path)   → { publicKey?: string; rawPublicKey: Buffer }
+//   app.signTransaction(path, txBytes) → { signature: Buffer }
+// ---------------------------------------------------------------------------
+declare module "@ledgerhq/hw-app-str" {
+  interface Transport {
+    close(): Promise<void>;
+  }
+
+  interface PublicKeyResult {
+    publicKey?: string;
+    rawPublicKey: Buffer;
+  }
+
+  interface SignatureResult {
+    signature: Buffer;
+  }
+
+  class Str {
+    constructor(transport: Transport);
+    getPublicKey(derivationPath: string): Promise<PublicKeyResult>;
+    signTransaction(
+      derivationPath: string,
+      txBytes: Buffer
+    ): Promise<SignatureResult>;
+  }
+
+  export default Str;
+}


### PR DESCRIPTION
Add ambient type declarations for optional Ledger peer dependencies

Problem

`packages/sdk/src/signers/ledger.ts` dynamically imports `@ledgerhq/hw-transport-webhid`, `@ledgerhq/hw-transport-node-hid`, and `@ledgerhq/hw-app-str` at runtime. These are optional peer dependencies, but TypeScript still resolves module specifiers at compile time, causing `TS2307` errors in environments where the native packages are not installed (e.g. CI without `libusb` or `node-gyp` build tools).

Solution

Added `packages/sdk/src/types/ledger-modules.d.ts` with ambient `declare module` blocks for all three packages. Each declaration exposes only the methods actually consumed by `ledger.ts` — no broader API surface is invented.

Since `tsconfig.json` already includes `src/**/*`, the file is picked up automatically with no configuration changes required.

Changes

- `packages/sdk/src/types/ledger-modules.d.ts` (new file)

Testing

Run `tsc --noEmit` from `packages/sdk` without the Ledger packages installed — the `TS2307` errors should no longer appear.

CLOSES #765