### PR TITLE
feat: SDK connection health checks with automatic reconnection (#784)

### DIFF
--- a/packages/sdk/src/__tests__/health.test.ts
+++ b/packages/sdk/src/__tests__/health.test.ts
@@ -1,0 +1,171 @@
+import { ConnectionHealthMonitor, ConnectionStatus } from "../health";
+
+const mockGetLatestLedger = jest.fn();
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  rpc: {
+    Server: jest.fn().mockImplementation(() => ({ getLatestLedger: mockGetLatestLedger })),
+    Api: {
+      isSimulationError: (r: unknown) => !!(r as { error?: unknown }).error,
+      isSimulationSuccess: (r: unknown) => !!(r as { result?: unknown }).result,
+    },
+  },
+  Contract: jest.fn(() => ({ call: jest.fn() })),
+  nativeToScVal: jest.fn((v: unknown) => v),
+  scValToNative: jest.fn((v: unknown) => v),
+  TransactionBuilder: jest.fn(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      toEnvelope: jest.fn().mockReturnValue({ toXDR: jest.fn().mockReturnValue("AAAA") }),
+    }),
+  })),
+  Account: jest.fn(),
+  Keypair: { random: jest.fn(() => ({ publicKey: () => "GDUMMY" })) },
+  StrKey: { isValidEd25519PublicKey: jest.fn(() => true) },
+  xdr: {},
+}));
+
+/** Wait for a condition to become true, polling every 10ms. */
+function waitFor(condition: () => boolean, timeoutMs = 500): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const poll = () => {
+      if (condition()) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error("waitFor timeout"));
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
+describe("ConnectionHealthMonitor", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("healthCheck()", () => {
+    it("returns true when RPC responds", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 100 });
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com");
+      expect(await monitor.healthCheck()).toBe(true);
+    });
+
+    it("returns false when RPC throws", async () => {
+      mockGetLatestLedger.mockRejectedValue(new Error("Network error"));
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com");
+      expect(await monitor.healthCheck()).toBe(false);
+    });
+  });
+
+  describe("periodic checks and status events", () => {
+    it("emits 'connected' when RPC comes online", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1 });
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com", { intervalMs: 50 });
+      const cb = jest.fn();
+      monitor.onConnectionStatusChange(cb);
+
+      await waitFor(() => cb.mock.calls.length > 0);
+      expect(cb).toHaveBeenCalledWith("connected");
+      monitor.stop();
+    });
+
+    it("emits 'disconnected' when RPC is unreachable", async () => {
+      mockGetLatestLedger.mockRejectedValue(new Error("timeout"));
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com", {
+        intervalMs: 50,
+        backoffMs: 50,
+      });
+      const cb = jest.fn();
+      monitor.onConnectionStatusChange(cb);
+
+      await waitFor(() => cb.mock.calls.length > 0);
+      expect(cb).toHaveBeenCalledWith("disconnected");
+      monitor.stop();
+    });
+
+    it("does not re-emit when status stays the same", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1 });
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com", { intervalMs: 30 });
+      const cb = jest.fn();
+      monitor.onConnectionStatusChange(cb);
+
+      // Wait for first emit, then wait for 2 more intervals — should still be just 1 call
+      await waitFor(() => cb.mock.calls.length > 0);
+      await new Promise((r) => setTimeout(r, 80));
+      expect(cb).toHaveBeenCalledTimes(1);
+      monitor.stop();
+    });
+
+    it("emits 'disconnected' then 'connected' on recovery", async () => {
+      let callCount = 0;
+      mockGetLatestLedger.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error("down"));
+        return Promise.resolve({ sequence: 5 });
+      });
+
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com", {
+        backoffMs: 30,
+        maxBackoffMs: 30,
+        intervalMs: 50,
+      });
+      const statuses: ConnectionStatus[] = [];
+      monitor.onConnectionStatusChange((s) => statuses.push(s));
+
+      await waitFor(() => statuses.includes("disconnected"));
+      await waitFor(() => statuses.includes("connected"));
+
+      expect(statuses).toEqual(["disconnected", "connected"]);
+      monitor.stop();
+    });
+  });
+
+  describe("stop()", () => {
+    it("stops further checks after stop() is called", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1 });
+      const monitor = new ConnectionHealthMonitor("https://rpc.example.com", { intervalMs: 20 });
+      monitor.start();
+      monitor.stop();
+
+      const callsBefore = mockGetLatestLedger.mock.calls.length;
+      await new Promise((r) => setTimeout(r, 60));
+      expect(mockGetLatestLedger.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe("LinkoraClient integration", () => {
+    let LinkoraClient: typeof import("../client").LinkoraClient;
+    beforeAll(async () => {
+      ({ LinkoraClient } = await import("../client"));
+    });
+
+    it("healthCheck() returns true on healthy RPC", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1 });
+      const client = new LinkoraClient({ contractId: "CDUMMY", rpcUrl: "https://rpc.example.com" });
+      expect(await client.healthCheck()).toBe(true);
+    });
+
+    it("healthCheck() returns false when RPC is down", async () => {
+      mockGetLatestLedger.mockRejectedValue(new Error("down"));
+      const client = new LinkoraClient({ contractId: "CDUMMY", rpcUrl: "https://rpc.example.com" });
+      expect(await client.healthCheck()).toBe(false);
+    });
+
+    it("onConnectionStatusChange starts checks and fires callback", async () => {
+      mockGetLatestLedger.mockResolvedValue({ sequence: 1 });
+      const client = new LinkoraClient({
+        contractId: "CDUMMY",
+        rpcUrl: "https://rpc.example.com",
+        healthCheck: { intervalMs: 50 },
+      });
+
+      const cb = jest.fn();
+      client.onConnectionStatusChange(cb);
+
+      await waitFor(() => cb.mock.calls.length > 0);
+      expect(cb).toHaveBeenCalledWith("connected");
+      client.stopHealthChecks();
+    });
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -15,6 +15,7 @@ import { Profile, Post, Pool, SimulationResult, LedgerFootprint } from "./types"
 import { mapError, NotFoundError, SimulationError, InvalidInputError } from "./errors";
 import { GovParameter } from "./generated/types";
 import type { GovProposal } from "./generated/types";
+import { ConnectionHealthMonitor, HealthCheckConfig, ConnectionStatusCallback } from "./health";
 
 const { isSimulationError, isSimulationSuccess } = rpc.Api;
 
@@ -92,6 +93,8 @@ export interface ClientConfig {
   networkPassphrase?: string;
   /** Contract ID of the token factory contract */
   tokenFactoryId?: string;
+  /** Connection health-check options */
+  healthCheck?: HealthCheckConfig & { autoStart?: boolean };
 }
 
 export interface DeployCreatorTokenParams {
@@ -119,6 +122,7 @@ export class LinkoraClient extends GeneratedLinkoraClient {
   private readonly _rpcUrl: string;
   private readonly _networkPassphrase: string;
   private readonly _contractId: string;
+  private readonly _healthMonitor: ConnectionHealthMonitor;
 
   constructor(config: ClientConfig) {
     super({
@@ -130,6 +134,29 @@ export class LinkoraClient extends GeneratedLinkoraClient {
     this.tokenFactoryId = config.tokenFactoryId;
     this._rpcUrl = config.rpcUrl;
     this._networkPassphrase = config.networkPassphrase || DEFAULT_NETWORK;
+
+    const { autoStart, ...healthCfg } = config.healthCheck ?? {};
+    this._healthMonitor = new ConnectionHealthMonitor(this._rpcUrl, healthCfg);
+    if (autoStart) this._healthMonitor.start();
+  }
+
+  /** Ping the RPC endpoint once. Returns true if reachable. */
+  healthCheck(): Promise<boolean> {
+    return this._healthMonitor.healthCheck();
+  }
+
+  /**
+   * Register a callback for connection status changes ("connected" | "disconnected").
+   * Starts the periodic health-check loop on first call if not already running.
+   */
+  onConnectionStatusChange(callback: ConnectionStatusCallback): void {
+    this._healthMonitor.onConnectionStatusChange(callback);
+    this._healthMonitor.start();
+  }
+
+  /** Stop the periodic health-check loop. */
+  stopHealthChecks(): void {
+    this._healthMonitor.stop();
   }
 
   // ── Soroban simulation and transaction preparation ─────────────────────────

--- a/packages/sdk/src/health.ts
+++ b/packages/sdk/src/health.ts
@@ -1,0 +1,100 @@
+import { rpc } from "@stellar/stellar-sdk";
+
+export type ConnectionStatus = "connected" | "disconnected";
+export type ConnectionStatusCallback = (status: ConnectionStatus) => void;
+
+export interface HealthCheckConfig {
+  /** Interval in ms between health checks. Default: 30000 */
+  intervalMs?: number;
+  /** Initial backoff in ms for reconnection attempts. Default: 1000 */
+  backoffMs?: number;
+  /** Maximum backoff cap in ms. Default: 30000 */
+  maxBackoffMs?: number;
+}
+
+/**
+ * Manages periodic RPC health checks, emits connected/disconnected events,
+ * and retries with exponential backoff on disconnect.
+ */
+export class ConnectionHealthMonitor {
+  private readonly rpcUrl: string;
+  private readonly intervalMs: number;
+  private readonly backoffMs: number;
+  private readonly maxBackoffMs: number;
+
+  private status: ConnectionStatus = "disconnected";
+  private listeners: ConnectionStatusCallback[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+
+  constructor(rpcUrl: string, config: HealthCheckConfig = {}) {
+    this.rpcUrl = rpcUrl;
+    this.intervalMs = config.intervalMs ?? 30_000;
+    this.backoffMs = config.backoffMs ?? 1_000;
+    this.maxBackoffMs = config.maxBackoffMs ?? 30_000;
+  }
+
+  /** Register a callback invoked whenever connection status changes. Starts the loop if not already running. */
+  onConnectionStatusChange(callback: ConnectionStatusCallback): void {
+    this.listeners.push(callback);
+    this.start();
+  }
+
+  /** Perform a single health check ping against the RPC endpoint. */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const server = new rpc.Server(this.rpcUrl);
+      await server.getLatestLedger();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Start periodic health checks. Idempotent — safe to call multiple times. */
+  start(): void {
+    if (this.timer !== null) return; // already running
+    this.stopped = false;
+    this.scheduleCheck(0);
+  }
+
+  /** Stop all periodic checks and clear timers. */
+  stop(): void {
+    this.stopped = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private scheduleCheck(delayMs: number): void {
+    this.timer = setTimeout(() => this.runCheck(), delayMs);
+  }
+
+  private async runCheck(): Promise<void> {
+    if (this.stopped) return;
+
+    const ok = await this.healthCheck();
+    const next: ConnectionStatus = ok ? "connected" : "disconnected";
+
+    if (next !== this.status) {
+      this.status = next;
+      for (const cb of this.listeners) cb(this.status);
+    }
+
+    if (!this.stopped) {
+      this.scheduleCheck(ok ? this.intervalMs : this.nextBackoff());
+    }
+  }
+
+  private _currentBackoff = 0;
+
+  private nextBackoff(): number {
+    if (this._currentBackoff === 0) {
+      this._currentBackoff = this.backoffMs;
+    } else {
+      this._currentBackoff = Math.min(this._currentBackoff * 2, this.maxBackoffMs);
+    }
+    return this._currentBackoff;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,7 @@ export * from "./mini-apps/validateManifest";
 export * from "./generated/events";
 export * from "./events/cursor";
 export * from "./events/subscriber";
+export * from "./health";
 export type {
   FollowEvent,
   LikePostEvent as LikeEvent,


### PR DESCRIPTION
## Summary

Closes #784

Implements RPC connection health monitoring with automatic reconnection and status change events in the SDK.

## Changes

### `packages/sdk/src/health.ts` (new)
- `ConnectionHealthMonitor` class handles all health check logic
- `healthCheck()` — single ping via `rpc.Server.getLatestLedger()`
- `start()` — begins periodic checks (idempotent)
- `stop()` — cancels all timers
- `onConnectionStatusChange(cb)` — registers listener and auto-starts the loop
- Emits `'connected'` / `'disconnected'` only when status actually changes
- Exponential backoff on disconnect: default 1s base, doubles each retry, capped at 30s
- Returns to normal interval once reconnected

### `packages/sdk/src/client.ts`
- `healthCheck(): Promise<boolean>` — single RPC ping
- `onConnectionStatusChange(callback)` — register listener, starts loop automatically
- `stopHealthChecks()` — stop the loop
- `ClientConfig.healthCheck` — optional config: `intervalMs` (default 30s), `backoffMs`, `maxBackoffMs`, `autoStart`

### `packages/sdk/src/index.ts`
- Exports `ConnectionHealthMonitor`, `ConnectionStatus`, `HealthCheckConfig`, `ConnectionStatusCallback`

## Usage
```ts
const client = new LinkoraClient({ contractId, rpcUrl });

// Single ping
const ok = await client.healthCheck();

// React to connection changes (starts loop automatically)
client.onConnectionStatusChange((status) => {
  if (status === 'disconnected') console.warn('RPC disconnected, retrying...');
  if (status === 'connected')   console.log('RPC reconnected');
});

// Or use autoStart
const client = new LinkoraClient({
  contractId, rpcUrl,
  healthCheck: { autoStart: true, intervalMs: 15_000 }
});

// Stop when done
client.stopHealthChecks();
```