### PR TITLE
feat: health check endpoints with dependency status for all services (#788)

### DIFF
--- a/services/analytics-oracle/src/index.ts
+++ b/services/analytics-oracle/src/index.ts
@@ -142,6 +142,53 @@ async function scheduleLoop(currentLedger: bigint): Promise<void> {
 // ── REST API ──────────────────────────────────────────────────────────────────
 
 const app = express();
+const SERVICE_VERSION = process.env["npm_package_version"] ?? "0.1.0";
+const COMMIT_SHA = process.env["COMMIT_SHA"] ?? "unknown";
+const startTime = Date.now();
+
+// ── Health endpoints ──────────────────────────────────────────────────────────
+
+app.get("/health", async (_req, res) => {
+  const uptime = Math.floor((Date.now() - startTime) / 1000);
+
+  let dbStatus = "disconnected";
+  try { await db.query("SELECT 1"); dbStatus = "connected"; } catch { /* */ }
+
+  let rpcStatus = "unreachable";
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 3000);
+    await fetch(SOROBAN_RPC_URL, {
+      method: "POST", signal: ctrl.signal,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getLatestLedger", params: [] }),
+    }).finally(() => clearTimeout(t));
+    rpcStatus = "reachable";
+  } catch { /* */ }
+
+  const ok = dbStatus === "connected" && rpcStatus === "reachable";
+  res.status(ok ? 200 : 503).json({
+    status: ok ? "ok" : "degraded",
+    uptime,
+    version: SERVICE_VERSION,
+    commit: COMMIT_SHA,
+    db: dbStatus,
+    rpc: rpcStatus,
+  });
+});
+
+app.get("/health/ready", async (_req, res) => {
+  try {
+    await db.query("SELECT 1");
+    res.json({ status: "ready" });
+  } catch {
+    res.status(503).json({ status: "not ready", reason: "db unavailable" });
+  }
+});
+
+app.get("/health/live", (_req, res) => {
+  res.json({ status: "live" });
+});
 
 /**
  * GET /attestations/:creator

--- a/services/dm-relay/src/database.ts
+++ b/services/dm-relay/src/database.ts
@@ -32,6 +32,10 @@ class Database {
     console.log('Database initialized successfully');
   }
 
+  async ping(): Promise<void> {
+    await this.pool.query('SELECT 1');
+  }
+
   private async createTables(): Promise<void> {
     const createMessagesTable = `
       CREATE TABLE IF NOT EXISTS dm_messages (

--- a/services/dm-relay/src/server.ts
+++ b/services/dm-relay/src/server.ts
@@ -26,6 +26,10 @@ import {
 // Load environment variables
 dotenv.config();
 
+const SERVICE_VERSION = process.env.npm_package_version ?? '0.1.0';
+const COMMIT_SHA = process.env.COMMIT_SHA ?? 'unknown';
+const startTime = Date.now();
+
 // Configuration
 const config = {
   port: parseInt(process.env.PORT || '3001'),
@@ -76,14 +80,38 @@ async function createApp() {
   // API routes
   app.use('/api', createRouter(database, authService));
 
-  // Health check at root
-  app.get('/', (req, res) => {
-    res.json({
-      service: 'linkora-dm-relay',
-      version: '0.1.0',
-      status: 'running',
-      timestamp: new Date().toISOString(),
+  // ── Health endpoints ───────────────────────────────────────────────────────
+
+  app.get('/health', async (_req, res) => {
+    const uptime = Math.floor((Date.now() - startTime) / 1000);
+    let dbStatus = 'disconnected';
+    try { await database.ping(); dbStatus = 'connected'; } catch { /* */ }
+    const ok = dbStatus === 'connected';
+    res.status(ok ? 200 : 503).json({
+      status: ok ? 'ok' : 'degraded',
+      uptime,
+      version: SERVICE_VERSION,
+      commit: COMMIT_SHA,
+      db: dbStatus,
     });
+  });
+
+  app.get('/health/ready', async (_req, res) => {
+    try {
+      await database.ping();
+      res.json({ status: 'ready' });
+    } catch {
+      res.status(503).json({ status: 'not ready', reason: 'db unavailable' });
+    }
+  });
+
+  app.get('/health/live', (_req, res) => {
+    res.json({ status: 'live' });
+  });
+
+  // Root info
+  app.get('/', (_req, res) => {
+    res.json({ service: 'linkora-dm-relay', version: SERVICE_VERSION, status: 'running' });
   });
 
   // Error handling

--- a/services/indexer/src/api/index.ts
+++ b/services/indexer/src/api/index.ts
@@ -27,23 +27,62 @@ export function createApp(db: Database, pg?: PgPool): express.Application {
   const app = express();
   app.use(express.json());
 
-  app.get("/health", (_req: Request, res: Response): void => {
+  const startTime = Date.now();
+  const version = process.env.npm_package_version ?? "0.1.0";
+  const commit = process.env.COMMIT_SHA ?? "unknown";
+
+  // ── Health endpoints ───────────────────────────────────────────────────────
+
+  app.get("/health", async (_req: Request, res: Response): Promise<void> => {
+    const uptime = Math.floor((Date.now() - startTime) / 1000);
     const backfill = getBackfillState();
-    res.json({
-      status: "ok",
-      backfill: backfill.active
-        ? {
-            active: true,
-            fromLedger: backfill.fromLedger,
-            toLedger: backfill.toLedger,
-            processedLedgers: backfill.processedLedgers,
-            totalLedgers:
-              backfill.toLedger !== undefined && backfill.fromLedger !== undefined
-                ? backfill.toLedger - backfill.fromLedger + 1
-                : undefined,
-          }
-        : { active: false },
+
+    // DB check
+    let dbStatus = "disconnected";
+    try {
+      if (pg) { await pg.query("SELECT 1"); dbStatus = "connected"; }
+    } catch { /* keep disconnected */ }
+
+    // RPC check
+    let rpcStatus = "unreachable";
+    try {
+      const rpcUrl = process.env.STELLAR_RPC_URL;
+      if (rpcUrl) {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), 3000);
+        await fetch(`${rpcUrl}`, { method: "POST", signal: ctrl.signal,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getLatestLedger", params: [] }),
+        }).finally(() => clearTimeout(t));
+        rpcStatus = "reachable";
+      }
+    } catch { /* keep unreachable */ }
+
+    const ok = dbStatus === "connected" && rpcStatus === "reachable";
+    res.status(ok ? 200 : 503).json({
+      status: ok ? "ok" : "degraded",
+      uptime,
+      version,
+      commit,
+      db: dbStatus,
+      rpc: rpcStatus,
+      backfill: backfill.active ? { active: true, fromLedger: backfill.fromLedger, toLedger: backfill.toLedger } : { active: false },
     });
+  });
+
+  // Readiness: ready to serve traffic (DB + RPC up)
+  app.get("/health/ready", async (_req: Request, res: Response): Promise<void> => {
+    try {
+      if (pg) await pg.query("SELECT 1");
+      res.json({ status: "ready" });
+    } catch {
+      res.status(503).json({ status: "not ready", reason: "db unavailable" });
+    }
+  });
+
+  // Liveness: process is alive
+  app.get("/health/live", (_req: Request, res: Response): void => {
+    res.json({ status: "live" });
   });
 
   // Apply rate limiting to all /api routes.


### PR DESCRIPTION
## Summary

Closes #788

Adds `GET /health`, `GET /health/ready`, and `GET /health/live` to all three services.

## Endpoints

| Endpoint | Purpose | Returns 503 when |
|---|---|---|
| `GET /health` | Full dependency status | Any dependency down |
| `GET /health/ready` | Kubernetes readiness probe | DB unreachable |
| `GET /health/live` | Kubernetes liveness probe | Never |

### `GET /health` response shape
```json
{
  "status": "ok",
  "uptime": 3600,
  "version": "0.1.0",
  "commit": "abc1234",
  "db": "connected",
  "rpc": "reachable"
}
```

## Changes per service

**indexer** (`services/indexer/src/api/index.ts`)
- Replaced the minimal `/health` stub with full dependency checks
- DB: `pg.query('SELECT 1')` against the injected `PgPool`
- RPC: `POST getLatestLedger` to `STELLAR_RPC_URL` with 3s timeout
- Version from `npm_package_version`, commit from `COMMIT_SHA` env var

**dm-relay** (`services/dm-relay/src/server.ts`, `database.ts`)
- Added `Database.ping()` public method
- `/health` checks DB, reports version/commit/uptime
- No RPC dependency in this service

**analytics-oracle** (`services/analytics-oracle/src/index.ts`)
- `/health` checks both PostgreSQL pool and `SOROBAN_RPC_URL` reachability
- `/health/ready` DB-only gate